### PR TITLE
set assignment id to null on revoke

### DIFF
--- a/Keas.Mvc/Controllers/Api/KeySerialsController.cs
+++ b/Keas.Mvc/Controllers/Api/KeySerialsController.cs
@@ -298,6 +298,7 @@ namespace Keas.Mvc.Controllers.Api
             // clear out assignment
             var assignment = keySerial.KeySerialAssignment;
             _context.KeySerialAssignments.Remove(assignment);
+            keySerial.KeySerialAssignmentId = null;
 
             await _context.SaveChangesAsync();
 


### PR DESCRIPTION
fixes #797.  Probably a few ways of doing this, but this was the simplest.  Ideally we would redo the mappings so that KeySerialAssignment doesn't contain KeySerialId, which would make it more in-line with EquipmentAssignment and the others.  But that would require Db changes and FK updates, so this gets the job done.