### PR TITLE
LH/remove oneOf for protectionLevel and accessLevel

### DIFF
--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentEditValues.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentEditValues.tsx
@@ -132,7 +132,6 @@ export default class EquipmentEditValues extends React.Component<IProps, {}> {
                   disabled={this.props.disableEditing}
                   invalid={error && error.path === 'protectionLevel'}
                 >
-                  {/* if you change these, be sure to change the schema */}
                   <option value='P1'>P1 - Minimal</option>
                   <option value='P2'>P2 - Low</option>
                   <option value='P3'>P3 - Moderate</option>
@@ -164,7 +163,6 @@ export default class EquipmentEditValues extends React.Component<IProps, {}> {
                   disabled={this.props.disableEditing}
                   invalid={error && error.path === 'availabilityLevel'}
                 >
-                  {/* if you change these, be sure to change the schema */}
                   <option value='A1'>A1 - Minimal</option>
                   <option value='A2'>A2 - Low</option>
                   <option value='A3'>A3 - Moderate</option>

--- a/Keas.Mvc/ClientApp/models/Equipment.ts
+++ b/Keas.Mvc/ClientApp/models/Equipment.ts
@@ -30,7 +30,6 @@ export const equipmentSchema = yup.object<IEquipment>().shape({
   availabilityLevel: yup
     .string()
     .max(2)
-    .oneOf(['', 'A1', 'A2', 'A3', 'A4']) // empty string will default to A1 depending on type
     .notRequired()
     .nullable(),
   equipmentAssignmentId: yup.number().nullable(),
@@ -54,7 +53,6 @@ export const equipmentSchema = yup.object<IEquipment>().shape({
   protectionLevel: yup
     .string()
     .max(2)
-    .oneOf(['', 'P1', 'P2', 'P3', 'P4']) // empty string will default to P1 depending on type
     .notRequired()
     .nullable(),
   serialNumber: yup


### PR DESCRIPTION
these are still behaving weird. this is sometimes null and sometimes an empty string and depends on the type, so I'm just removing the `oneOf` check alltogether since it doesn't get us much