### PR TITLE
Transition away from Sparkpost library to raw SMTP

### DIFF
--- a/Keas.Core/Keas.Core.csproj
+++ b/Keas.Core/Keas.Core.csproj
@@ -9,6 +9,5 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
     <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="SparkPost" Version="1.14.0" />
   </ItemGroup>
 </Project>

--- a/Keas.Core/Models/SparkpostSettings.cs
+++ b/Keas.Core/Models/SparkpostSettings.cs
@@ -8,5 +8,9 @@ namespace Keas.Core.Models
     {
         public string ApiKey { get; set; }
         public string DisableSend { get; set; }
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string Host { get; set; }
+        public int Port { get; set; }
     }
 }

--- a/Keas.Jobs.SendMail/appsettings.json
+++ b/Keas.Jobs.SendMail/appsettings.json
@@ -4,7 +4,11 @@
   },
   "Sparkpost": {
     "ApiKey": "[External]",
-    "DisableSend": "[External]" 
+    "DisableSend": "[External]",
+    "UserName": "[External]",
+    "Password": "[External]",
+    "Host": "[External]",
+    "Port": 1
   },
   "Stackify": {
     "AppName": "PEAKS-EmailJob"


### PR DESCRIPTION
SparkPost Lib is not compatible with .net standard and causes other problems and we don't need it.  This will require adding some smtp settings to production before we deploy.  The emails themselves and routing should be exactly the same, as we are still using SparkPost for the actual sending, just via another method.

closes #874