### PR TITLE
Made Date-Picker disabled on deleting person modal

### DIFF
--- a/Keas.Mvc/ClientApp/components/People/CreatePerson.tsx
+++ b/Keas.Mvc/ClientApp/components/People/CreatePerson.tsx
@@ -74,6 +74,7 @@ export default class CreatePerson extends React.Component<IProps, IState> {
                   disableEditing={false}
                   tags={this.props.tags}
                   error={this.state.error}
+                  isDeleting={false}
                 />
               </div>
 

--- a/Keas.Mvc/ClientApp/components/People/DeletePerson.tsx
+++ b/Keas.Mvc/ClientApp/components/People/DeletePerson.tsx
@@ -56,6 +56,7 @@ export default class DeletePerson extends React.Component<IProps, IState> {
             <PersonEditValues
               selectedPerson={this.props.selectedPersonInfo.person}
               disableEditing={true}
+              isDeleting={true}
             />
             {!this._checkValidToDelete() && (
               <div>

--- a/Keas.Mvc/ClientApp/components/People/EditPerson.tsx
+++ b/Keas.Mvc/ClientApp/components/People/EditPerson.tsx
@@ -77,6 +77,7 @@ export default class EditPerson extends React.Component<IProps, IState> {
                   disableEditing={false}
                   tags={this.props.tags}
                   error={this.state.error}
+                  isDeleting={false}
                 />
               </form>
             </div>

--- a/Keas.Mvc/ClientApp/components/People/PersonEditValues.tsx
+++ b/Keas.Mvc/ClientApp/components/People/PersonEditValues.tsx
@@ -17,6 +17,7 @@ interface IProps {
   space?: ISpace;
   creating?: boolean;
   error?: IValidationError;
+  isDeleting?: boolean;
 }
 
 export default class PersonEditValues extends React.Component<IProps, {}> {
@@ -153,6 +154,7 @@ export default class PersonEditValues extends React.Component<IProps, {}> {
           <Label for='Start Date'>Start Date</Label>
           <br />
           <DatePicker
+            disabled={this.props.isDeleting}
             value={
               this.props.selectedPerson && this.props.selectedPerson.startDate
                 ? new Date(this.props.selectedPerson.startDate)
@@ -168,6 +170,7 @@ export default class PersonEditValues extends React.Component<IProps, {}> {
           <Label for='End Date'>End Date</Label>
           <br />
           <DatePicker
+            disabled={this.props.isDeleting}
             value={
               this.props.selectedPerson && this.props.selectedPerson.endDate
                 ? new Date(this.props.selectedPerson.endDate)


### PR DESCRIPTION
Added a new prop for PersonEditValues component, `isDeleting`
If false then the the user can edit the date
If true then the field will be disabled

closes #907