### PR TITLE
create equipment and workstation reports for super teams

### DIFF
--- a/Keas.Core/Domain/Team.cs
+++ b/Keas.Core/Domain/Team.cs
@@ -43,6 +43,8 @@ namespace Keas.Core.Domain
         public List<FinancialOrganization> FISOrgs { get; set; }
 
         public List<TeamPpsDepartment> PpsDepartments { get; set; }
+
+        public List<GroupXTeam> Groups { get; set; }
        
     }
 }

--- a/Keas.Core/Domain/Team.cs
+++ b/Keas.Core/Domain/Team.cs
@@ -44,6 +44,7 @@ namespace Keas.Core.Domain
 
         public List<TeamPpsDepartment> PpsDepartments { get; set; }
 
+        [JsonIgnore]
         public List<GroupXTeam> Groups { get; set; }
        
     }

--- a/Keas.Mvc/Controllers/GroupController.cs
+++ b/Keas.Mvc/Controllers/GroupController.cs
@@ -1,8 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Keas.Core.Data;
+using Keas.Mvc.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -13,10 +12,12 @@ namespace Keas.Mvc.Controllers
     public class GroupController : SuperController
     {
         private readonly ApplicationDbContext _context;
+        private readonly IReportService _reportService;
 
-        public GroupController(ApplicationDbContext context)
+        public GroupController(ApplicationDbContext context, IReportService reportService)
         {
             _context = context;
+            _reportService = reportService;
         }
         public async Task<IActionResult> Index(int id)
         {
@@ -30,6 +31,23 @@ namespace Keas.Mvc.Controllers
             }
 
             return View(group);
+        }
+
+        public async Task<IActionResult> WorkstationReport(int id)
+        {
+            // TODO: create auth policy for group membership
+            var group = await _context.Groups.SingleOrDefaultAsync(a =>
+                a.Id == id && a.GroupPermissions.Any(w => w.UserId == User.Identity.Name));
+
+            if (group == null)
+            {
+                ErrorMessage = "Group not found or no access to Group";
+                return RedirectToAction("NoAccess", "Home");
+            }
+
+            var worstations = await _reportService.WorkStations(group);
+
+            return View(worstations);
         }
     }
 }

--- a/Keas.Mvc/Controllers/GroupController.cs
+++ b/Keas.Mvc/Controllers/GroupController.cs
@@ -49,5 +49,22 @@ namespace Keas.Mvc.Controllers
 
             return View(worstations);
         }
+
+        public async Task<IActionResult> EquipmentReport(int id)
+        {
+            // TODO: create auth policy for group membership
+            var group = await _context.Groups.SingleOrDefaultAsync(a =>
+                a.Id == id && a.GroupPermissions.Any(w => w.UserId == User.Identity.Name));
+
+            if (group == null)
+            {
+                ErrorMessage = "Group not found or no access to Group";
+                return RedirectToAction("NoAccess", "Home");
+            }
+
+            var equipment = await _reportService.EquipmentList(group);
+
+            return View(equipment);
+        }
     }
 }

--- a/Keas.Mvc/Views/Group/EquipmentReport.cshtml
+++ b/Keas.Mvc/Views/Group/EquipmentReport.cshtml
@@ -5,6 +5,7 @@
     ViewBag.Title = "Equipment";
 }
 
+<a asp-action="Index" class="btn btn-link">Back to Group Home</a>
 
 <div class="card">
     <div class="card-header-equipment">

--- a/Keas.Mvc/Views/Group/EquipmentReport.cshtml
+++ b/Keas.Mvc/Views/Group/EquipmentReport.cshtml
@@ -5,12 +5,12 @@
     ViewBag.Title = "Equipment";
 }
 
-<a asp-action="Index" class="btn btn-link">Back to Group Home</a>
+<a asp-action="Index" asp-route-id="@ViewBag.Group.Id" class="btn btn-link">Back to Group Home</a>
 
 <div class="card">
     <div class="card-header-equipment">
         <div class="card-head">
-            <h2>Group Equipment Report</h2>
+            <h2>@ViewBag.Group.Name Group Equipment Report</h2>
             <small class="form-text text-muted">To see more details, export the results with one of the buttons on the table (Copy, Excel, etc.).</small>
             <small class="form-text text-muted">If you have filtered the report with the Search feature, only the filtered results will be exported.</small>
             <small class="form-text text-muted">You can filter the table with the data that isn't displayed on the screen (such as notes).</small>

--- a/Keas.Mvc/Views/Group/EquipmentReport.cshtml
+++ b/Keas.Mvc/Views/Group/EquipmentReport.cshtml
@@ -1,0 +1,133 @@
+@using Keas.Core.Extensions
+@model System.Collections.Generic.IList<Keas.Mvc.Models.ReportModels.EquipmentReportModel>
+
+@{
+    ViewBag.Title = "Equipment";
+}
+
+
+<div class="card">
+    <div class="card-header-equipment">
+        <div class="card-head">
+            <h2>Group Equipment Report</h2>
+            <small class="form-text text-muted">To see more details, export the results with one of the buttons on the table (Copy, Excel, etc.).</small>
+            <small class="form-text text-muted">If you have filtered the report with the Search feature, only the filtered results will be exported.</small>
+            <small class="form-text text-muted">You can filter the table with the data that isn't displayed on the screen (such as notes).</small>
+        </div>
+    </div>
+    <div class="card-content">
+
+        <table id="equipment" class="table dataTable">
+            <thead>
+                <tr>
+                    <th>Equip Name</th>
+                    <th>Active</th>
+                    <th>Assigned</th>
+                    <th>Space?</th>
+                    <th>Notes?</th>
+                    <th># Attributes</th>
+                    <th>Type</th>
+                    <th>Protection Level</th>
+                    <th>Availability Level</th>
+                    <th>Bigfix Id</th>
+                    <th>Serial</th>
+                    <th>Make</th>
+                    <th>Model</th>
+                    <th>Tags</th>
+                    <th>Notes</th>
+                    <th>Assigned To</th>
+                    <th>Email</th>
+                    <th>Expires</th>
+                    <th>Room Number</th>
+                    <th>Building</th>
+                    <th>Room Name</th>
+                    <th>Floor</th>
+                    <th>Category</th>
+                    <th>Footage</th>
+                    <th>Attributes</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in Model)
+                {
+                    <tr>
+                        <td>@item.Name</td>
+                        <td>@item.Active.ToYesNoString()</td>
+                        <td>@item.IsAssigned.ToYesNoString()</td>
+                        <td>@item.HasSpace.ToYesNoString()</td>
+                        <td>@((!string.IsNullOrWhiteSpace(item.Notes)).ToYesNoString())</td>
+                        <td>@item.AttributeCount</td>
+                        <td>@item.Type</td>
+                        <td>@item.ProtectionLevel</td>
+                        <td>@item.AvailabilityLevel</td>
+                        <td>@item.SystemManagementId</td>
+                        <td>@item.SerialNumber</td>
+                        <td>@item.Make</td>
+                        <td>@item.Model</td>                        
+                        <td>@item.Tags.Replace(",",", ")</td>                        
+                        <td>@item.Notes</td>
+                        @if (item.IsAssigned)
+                        {
+                            <td>@($"{item.Assignment.FullName} ({item.Assignment.UserId})")</td>
+                            <td>@item.Assignment.Email</td>
+                            <td>@item.Assignment.ExpiryDateTime.ToPacificTime().ToShortDateString()</td>
+                        }
+                        else
+                        {
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        }
+                        @if (item.HasSpace)
+                        {
+                            <td>@item.Space.RoomNumber</td>
+                            <td>@item.Space.BldgName</td>
+                            <td>@item.Space.RoomName</td>
+                            <td>@item.Space.FloorName</td>
+                            <td>@item.Space.RoomCategoryName</td>
+                            <td>@item.Space.SqFt</td>
+                        }
+                        else
+                        {
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        }
+                        <td>@item.Attributes.Beautiful()</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+
+@section Styles {
+    @await Html.PartialAsync("_ImportResultsStylePartial")
+}
+
+@section Scripts {
+   @{await Html.RenderPartialAsync("_ImportJS");}  
+    
+    <script type="text/javascript">
+        $('.dataTable').DataTable({
+                "dom": 'lBfrtip',
+                "buttons": [
+                    { extend: 'copyHtml5' },
+                    { extend: 'excelHtml5' },
+                    { extend: 'csvHtml5' },
+                    { extend: 'print'},
+                ],
+                "columnDefs": [
+                    { "type": "date", "targets": [17] },
+                    { "targets" : [ 7,8,9,11,12,14,16,18,19,20,21,22,23,24], "visible" : false}
+                ]
+        });
+    </script>
+}
+
+
+

--- a/Keas.Mvc/Views/Group/Index.cshtml
+++ b/Keas.Mvc/Views/Group/Index.cshtml
@@ -4,5 +4,33 @@
     ViewBag.Title = "title";
 }
 
-<h2>Place Holder @Model.Name</h2>
+<h2>Welcome to the @Model.Name Group</h2>
+
+<div class="row justify-content-between">
+    <div class="col-md-6">
+        <div class="card equipment-color">
+            <div class="card-header-equipment">
+                <div class="card-head">
+                    <h2>Equipment List</h2>
+                </div>
+            </div>
+            <div class="card-content">
+                <a asp-action="EquipmentReport" asp-route-id="@Model.Id" class="btn btn-link">All Equipment <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card spaces-color">
+            <div class="card-header-spaces">
+                <div class="card-head">
+                    <h2>Workstations</h2>
+                </div>
+            </div>
+            <div class="card-content">
+                <a asp-action="WorkstationReport" asp-route-id="@Model.Id" class="btn btn-link">Workstation Information <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></a>
+            </div>
+        </div>
+    </div>
+</div>
+
 

--- a/Keas.Mvc/Views/Group/WorkstationReport.cshtml
+++ b/Keas.Mvc/Views/Group/WorkstationReport.cshtml
@@ -6,6 +6,8 @@
 
 }
 
+<a asp-action="Index" class="btn btn-link">Back to Group Home</a>
+
 <div class="card">
     <div class="card-header-spaces">
         <div class="card-head">

--- a/Keas.Mvc/Views/Group/WorkstationReport.cshtml
+++ b/Keas.Mvc/Views/Group/WorkstationReport.cshtml
@@ -6,12 +6,12 @@
 
 }
 
-<a asp-action="Index" class="btn btn-link">Back to Group Home</a>
+<a asp-action="Index" asp-route-id="@ViewBag.Group.Id" class="btn btn-link">Back to Group Home</a>
 
 <div class="card">
     <div class="card-header-spaces">
         <div class="card-head">
-            <h2>Group Workstations Report</h2>
+            <h2>@ViewBag.Group.Name Group Workstations Report</h2>
             <small class="form-text text-muted">To see more details, export the results with one of the buttons on the table (Copy, Excel, etc.).</small>
             <small class="form-text text-muted">If you have filtered the report with the Search feature, only the filtered results will be exported.</small>
             <small class="form-text text-muted">You can filter the table with the data that isn't displayed on the screen (such as notes).</small>

--- a/Keas.Mvc/Views/Group/WorkstationReport.cshtml
+++ b/Keas.Mvc/Views/Group/WorkstationReport.cshtml
@@ -1,0 +1,99 @@
+@using Keas.Core.Extensions
+@model System.Collections.Generic.IList<Keas.Mvc.Models.ReportModels.WorkstationReportModel>
+
+@{
+    ViewBag.Title = "Workstations";
+
+}
+
+<div class="card">
+    <div class="card-header-spaces">
+        <div class="card-head">
+            <h2>Group Workstations Report</h2>
+            <small class="form-text text-muted">To see more details, export the results with one of the buttons on the table (Copy, Excel, etc.).</small>
+            <small class="form-text text-muted">If you have filtered the report with the Search feature, only the filtered results will be exported.</small>
+            <small class="form-text text-muted">You can filter the table with the data that isn't displayed on the screen (such as notes).</small>
+        </div>
+    </div>
+    <div class="card-content">
+
+        <table id="workstations" class="table dataTable">
+            <thead>
+                <tr>
+                    <th>WS Name</th>
+                    <th>Active</th>
+                    <th>Assigned</th>
+                    <th>Tags</th>
+                    <th>Notes?</th>
+                    <th>Notes</th>
+                    <th>Assigned To</th>
+                    <th>Email</th>
+                    <th>Expires</th>
+                    <th>Room Number</th>
+                    <th>Building</th>
+                    <th>Room Name</th>
+                    <th>Floor</th>
+                    <th>Category</th>
+                    <th>Footage</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in Model)
+                {
+                    <tr>
+                        <td>@item.Name</td>
+                        <td>@item.Active.ToYesNoString()</td>
+                        <td>@item.IsAssigned.ToYesNoString()</td>
+                        <td>@item.Tags.Replace(",",", ")</td>
+                        <td>@((!string.IsNullOrWhiteSpace(item.Notes)).ToYesNoString())</td>
+                        <td>@item.Notes</td>
+                        @if (item.IsAssigned)
+                        {
+                            <td>@($"{item.Assignment.FullName} ({item.Assignment.UserId})")</td>
+                            <td>@item.Assignment.Email</td>
+                            <td>@item.Assignment.ExpiryDateTime.ToPacificTime().ToShortDateString()</td>
+                        }
+                        else
+                        {
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        }
+                        <td>@item.Space.RoomNumber</td>
+                        <td>@item.Space.BldgName</td>
+                        <td>@item.Space.RoomName</td>
+                        <td>@item.Space.FloorName</td>
+                        <td>@item.Space.RoomCategoryName</td>
+                        <td>@item.Space.SqFt</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+
+@section Styles {
+    @await Html.PartialAsync("_ImportResultsStylePartial")
+}
+
+@section Scripts {
+   @{await Html.RenderPartialAsync("_ImportJS");}  
+    
+    <script type="text/javascript">
+        $('.dataTable').DataTable({
+                "dom": 'lBfrtip',
+                "buttons": [
+                    { extend: 'copyHtml5' },
+                    { extend: 'excelHtml5' },
+                    { extend: 'csvHtml5' },
+                    { extend: 'print'},
+                ],
+                "columnDefs": [
+                    { "type": "date", "targets": [8] },
+                    { "targets" : [ 5,7,11,13,14], "visible" : false}
+                ]
+        });
+    </script>
+}
+

--- a/Test/TestsDatabase/TeamTests.cs
+++ b/Test/TestsDatabase/TeamTests.cs
@@ -44,6 +44,10 @@ namespace Test.TestsDatabase
                 "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)256)]",
             }));  
             expectedFields.Add(new NameAndType("FISOrgs", "System.Collections.Generic.List`1[Keas.Core.Domain.FinancialOrganization]", new List<string>()));
+            expectedFields.Add(new NameAndType("Groups", "System.Collections.Generic.List`1[Keas.Core.Domain.GroupXTeam]", new List<string>
+            {
+                "[Newtonsoft.Json.JsonIgnoreAttribute()]",
+            }));
             expectedFields.Add(new NameAndType("Id", "System.Int32", new List<string>
             {
                 "[System.ComponentModel.DataAnnotations.KeyAttribute()]",
@@ -66,7 +70,7 @@ namespace Test.TestsDatabase
             expectedFields.Add(new NameAndType("TeamPermissions", "System.Collections.Generic.ICollection`1[Keas.Core.Domain.TeamPermission]", new List<string>
             {
                 "[Newtonsoft.Json.JsonIgnoreAttribute()]",
-            }));        
+            }));
             #endregion Arrange
 
             AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(Team));


### PR DESCRIPTION
I refactored the report service to be able to serve group query projections.  This will work until the group and team reports diverge.  For the UI, I copied the html instead of making a partial, since it wasn't that large/complex and it seems more likely to change.

Probably could be a little cleaner if we make a security policy.

closes #770.
