### PR TITLE
Got rid of loosing filtering for equipment table

### DIFF
--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentDetails.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentDetails.tsx
@@ -24,7 +24,6 @@ export default class EquipmentDetails extends React.Component<IProps, {}> {
     if (!this.props.selectedEquipment) {
       return;
     }
-    this._fetchDetails(this.props.selectedEquipment.id);
   }
 
   public render() {
@@ -63,26 +62,4 @@ export default class EquipmentDetails extends React.Component<IProps, {}> {
       </div>
     );
   }
-
-  private _fetchDetails = async (id: number) => {
-    const url = `/api/${this.context.team.slug}/equipment/details/${id}`;
-    let equipment: IEquipment = null;
-    try {
-      equipment = await this.context.fetch(url);
-    } catch (err) {
-      if (err.message === 'Not Found') {
-        toast.error(
-          'The equipment you were trying to view could not be found. It may have been deleted.'
-        );
-        this.props.updateSelectedEquipment(null, id);
-        this.props.closeModal();
-      } else {
-        toast.error(
-          'Error fetching equipment details. Please refresh the page to try again.'
-        );
-      }
-      return;
-    }
-    this.props.updateSelectedEquipment(equipment);
-  };
 }

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentDetails.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentDetails.tsx
@@ -1,5 +1,4 @@
 ﻿import * as React from 'react';
-import { toast } from 'react-toastify';
 import { Button, Modal, ModalBody } from 'reactstrap';
 import { Context } from '../../Context';
 import { IEquipment } from '../../models/Equipment';

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentDetails.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentDetails.tsx
@@ -1,4 +1,5 @@
 ﻿import * as React from 'react';
+import { toast } from 'react-toastify';
 import { Button, Modal, ModalBody } from 'reactstrap';
 import { Context } from '../../Context';
 import { IEquipment } from '../../models/Equipment';
@@ -23,6 +24,7 @@ export default class EquipmentDetails extends React.Component<IProps, {}> {
     if (!this.props.selectedEquipment) {
       return;
     }
+    this._fetchDetails(this.props.selectedEquipment.id);
   }
 
   public render() {
@@ -61,4 +63,26 @@ export default class EquipmentDetails extends React.Component<IProps, {}> {
       </div>
     );
   }
+
+  private _fetchDetails = async (id: number) => {
+    const url = `/api/${this.context.team.slug}/equipment/details/${id}`;
+    let equipment: IEquipment = null;
+    try {
+      equipment = await this.context.fetch(url);
+    } catch (err) {
+      if (err.message === 'Not Found') {
+        toast.error(
+          'The equipment you were trying to view could not be found. It may have been deleted.'
+        );
+        this.props.updateSelectedEquipment(null, id);
+        this.props.closeModal();
+      } else {
+        toast.error(
+          'Error fetching equipment details. Please refresh the page to try again.'
+        );
+      }
+      return;
+    }
+    this.props.updateSelectedEquipment(equipment);
+  };
 }

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentTable.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentTable.tsx
@@ -20,14 +20,44 @@ interface IProps {
   onEdit?: (equipment: IEquipment) => void;
 }
 
-export default class EquipmentTable extends React.Component<IProps, {}> {
-  public render() {
-    const columns: Column<IEquipment>[] = [
+const EquipmentTable = (props: IProps) => {
+  const renderDropdownColumn = data => {
+    const equipmentEntity: IEquipment = data.row.original;
+    const hasAssignment = !!equipmentEntity.assignment;
+
+    const actions: IAction[] = [];
+
+    if (!!props.onAdd && !hasAssignment) {
+      actions.push({
+        onClick: () => props.onAdd(equipmentEntity),
+        title: 'Assign'
+      });
+    }
+
+    if (!!props.onRevoke && hasAssignment) {
+      actions.push({
+        onClick: () => props.onRevoke(equipmentEntity),
+        title: 'Revoke'
+      });
+    }
+
+    if (!!props.onDelete) {
+      actions.push({
+        onClick: () => props.onDelete(equipmentEntity),
+        title: 'Delete'
+      });
+    }
+
+    return <ListActionsDropdown actions={actions} />;
+  };
+
+  const columns: Column<IEquipment>[] = React.useMemo(
+    () => [
       {
         Cell: data => (
           <Button
             color='link'
-            onClick={() => this.props.showDetails(data.row.original)}
+            onClick={() => props.showDetails(data.row.original)}
           >
             Details
           </Button>
@@ -59,54 +89,32 @@ export default class EquipmentTable extends React.Component<IProps, {}> {
         id: 'expiresAt'
       },
       {
-        Cell: this.renderDropdownColumn,
+        Cell: renderDropdownColumn,
         Header: 'Actions',
         defaultCanFilter: false
       }
-    ];
+    ],
+    []
+  );
 
-    const initialState: Partial<TableState<any>> = {
-      sortBy: [{ id: 'name' }],
-      pageSize: ReactTableUtil.getPageSize()
-    };
+  const equipmentData = React.useMemo(
+    () => props.equipment,
+    [],
+  );
 
-    return (
-      <ReactTable
-        data={this.props.equipment}
-        columns={columns}
-        initialState={initialState}
-        filterTypes={{ expiration: expirationFilter }}
-      />
-    );
-  }
-
-  private renderDropdownColumn = data => {
-    const equipmentEntity: IEquipment = data.row.original;
-    const hasAssignment = !!equipmentEntity.assignment;
-
-    const actions: IAction[] = [];
-
-    if (!!this.props.onAdd && !hasAssignment) {
-      actions.push({
-        onClick: () => this.props.onAdd(equipmentEntity),
-        title: 'Assign'
-      });
-    }
-
-    if (!!this.props.onRevoke && hasAssignment) {
-      actions.push({
-        onClick: () => this.props.onRevoke(equipmentEntity),
-        title: 'Revoke'
-      });
-    }
-
-    if (!!this.props.onDelete) {
-      actions.push({
-        onClick: () => this.props.onDelete(equipmentEntity),
-        title: 'Delete'
-      });
-    }
-
-    return <ListActionsDropdown actions={actions} />;
+  const initialState: Partial<TableState<any>> = {
+    sortBy: [{ id: 'name' }],
+    pageSize: ReactTableUtil.getPageSize()
   };
-}
+
+  return (
+    <ReactTable
+      data={equipmentData}
+      columns={columns}
+      initialState={initialState}
+      filterTypes={{ expiration: expirationFilter }}
+    />
+  );
+};
+
+export default EquipmentTable;

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentTable.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentTable.tsx
@@ -97,10 +97,7 @@ const EquipmentTable = (props: IProps) => {
     []
   );
 
-  const equipmentData = React.useMemo(
-    () => props.equipment,
-    [],
-  );
+  const equipmentData = React.useMemo(() => props.equipment, []);
 
   const initialState: Partial<TableState<any>> = {
     sortBy: [{ id: 'name' }],

--- a/Keas.Mvc/ClientApp/components/Keys/KeySerialTable.tsx
+++ b/Keas.Mvc/ClientApp/components/Keys/KeySerialTable.tsx
@@ -60,15 +60,37 @@ const statusFilter = (rows: any[], id, filterValue) => {
 
 const getRowStatus = (row: any) => row.original?.status;
 
-export default class KeySerialTable extends React.Component<IProps, {}> {
-  public render() {
-    const { keySerials } = this.props;
-    const columns: Column<IKeySerial>[] = [
+// export default class KeySerialTable extends React.Component<IProps, {}> {
+const KeySerialTable = (props: IProps) => {
+  const renderDropdownColumn = data => {
+    const keySerial = data.row.original;
+
+    const actions: IAction[] = [];
+    if (!!props.onAssign && !keySerial.keySerialAssignment) {
+      actions.push({
+        onClick: () => props.onAssign(keySerial),
+        title: 'Assign'
+      });
+    }
+
+    if (!!props.onRevoke && !!keySerial.keySerialAssignment) {
+      actions.push({
+        onClick: () => props.onRevoke(keySerial),
+        title: 'Revoke'
+      });
+    }
+
+    return <ListActionsDropdown actions={actions} />;
+  };
+
+  const { keySerials } = props;
+  const columns: Column<IKeySerial>[] = React.useMemo(
+    () => [
       {
         Cell: data => (
           <Button
             color='link'
-            onClick={() => this.props.showDetails(data.row.original)}
+            onClick={() => props.showDetails(data.row.original)}
           >
             Details
           </Button>
@@ -108,44 +130,28 @@ export default class KeySerialTable extends React.Component<IProps, {}> {
         id: 'expiresAt'
       },
       {
-        Cell: this.renderDropdownColumn,
+        Cell: renderDropdownColumn,
         Header: 'Actions'
       }
-    ];
+    ],
+    []
+  );
 
-    const initialState: Partial<TableState<any>> = {
-      sortBy: [{ id: 'status' }, { id: 'keyCodeSN'}],
-      pageSize: ReactTableUtil.getPageSize()
-    };
+  const keySerialData = React.useMemo(() => keySerials, []);
 
-    return (
-      <ReactTable
-        data={keySerials}
-        columns={columns}
-        initialState={initialState}
-        filterTypes={{ expiration: expirationFilter, status: statusFilter }}
-      />
-    );
-  }
-
-  private renderDropdownColumn = data => {
-    const keySerial = data.row.original;
-
-    const actions: IAction[] = [];
-    if (!!this.props.onAssign && !keySerial.keySerialAssignment) {
-      actions.push({
-        onClick: () => this.props.onAssign(keySerial),
-        title: 'Assign'
-      });
-    }
-
-    if (!!this.props.onRevoke && !!keySerial.keySerialAssignment) {
-      actions.push({
-        onClick: () => this.props.onRevoke(keySerial),
-        title: 'Revoke'
-      });
-    }
-
-    return <ListActionsDropdown actions={actions} />;
+  const initialState: Partial<TableState<any>> = {
+    sortBy: [{ id: 'status' }, { id: 'keyCodeSN' }],
+    pageSize: ReactTableUtil.getPageSize()
   };
-}
+
+  return (
+    <ReactTable
+      data={keySerialData}
+      columns={columns}
+      initialState={initialState}
+      filterTypes={{ expiration: expirationFilter, status: statusFilter }}
+    />
+  );
+};
+
+export default KeySerialTable;

--- a/Keas.Mvc/ClientApp/components/Keys/KeySerialTable.tsx
+++ b/Keas.Mvc/ClientApp/components/Keys/KeySerialTable.tsx
@@ -60,7 +60,6 @@ const statusFilter = (rows: any[], id, filterValue) => {
 
 const getRowStatus = (row: any) => row.original?.status;
 
-// export default class KeySerialTable extends React.Component<IProps, {}> {
 const KeySerialTable = (props: IProps) => {
   const renderDropdownColumn = data => {
     const keySerial = data.row.original;


### PR DESCRIPTION
closes #962 

I removed the `fetchDetails` function since the selected equipment passed in the component is the exact same as the equipment returned from `fetchDetails`. I think that this is not necessary and it does not remove the filter as well.