### PR TITLE
Limit swagger content type to application/json

### DIFF
--- a/Keas.Mvc/Controllers/Api/AccessController.cs
+++ b/Keas.Mvc/Controllers/Api/AccessController.cs
@@ -20,6 +20,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.AccessMasterAccess)]
     [ApiController]
     [Route("api/{teamName}/access/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class AccessController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Keas.Mvc/Controllers/Api/DocumentController.cs
+++ b/Keas.Mvc/Controllers/Api/DocumentController.cs
@@ -16,6 +16,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.DocumentMasterAccess)]
     [ApiController]
     [Route("api/{teamName}/documents/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class DocumentsController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Keas.Mvc/Controllers/Api/EquipmentController.cs
+++ b/Keas.Mvc/Controllers/Api/EquipmentController.cs
@@ -21,6 +21,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.EquipMasterAccess)]
     [ApiController]
     [Route("api/{teamName}/equipment/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class EquipmentController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Keas.Mvc/Controllers/Api/KeySerialsController.cs
+++ b/Keas.Mvc/Controllers/Api/KeySerialsController.cs
@@ -21,6 +21,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.KeyMasterAccess)]
     [ApiController]
     [Route("api/{teamName}/KeySerials/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class KeySerialsController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Keas.Mvc/Controllers/Api/KeysController.cs
+++ b/Keas.Mvc/Controllers/Api/KeysController.cs
@@ -21,6 +21,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.KeyMasterAccess)]
     [ApiController]
     [Route("api/{teamName}/keys/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class KeysController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Keas.Mvc/Controllers/Api/PeopleAdminController.cs
+++ b/Keas.Mvc/Controllers/Api/PeopleAdminController.cs
@@ -19,6 +19,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.PersonManagerAccess)]
     [ApiController]
     [Route("api/{teamName}/peopleadmin/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class PeopleAdminController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Keas.Mvc/Controllers/Api/PeopleController.cs
+++ b/Keas.Mvc/Controllers/Api/PeopleController.cs
@@ -20,6 +20,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.AnyRole)]
     [ApiController]
     [Route("api/{teamName}/people/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class PeopleController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Keas.Mvc/Controllers/Api/SpacesController.cs
+++ b/Keas.Mvc/Controllers/Api/SpacesController.cs
@@ -18,6 +18,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.AnyRole)]
     [ApiController]
     [Route("api/{teamName}/spaces/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class SpacesController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Keas.Mvc/Controllers/Api/WorkstationsController.cs
+++ b/Keas.Mvc/Controllers/Api/WorkstationsController.cs
@@ -20,6 +20,8 @@ namespace Keas.Mvc.Controllers.Api
     [Authorize(Policy = AccessCodes.Codes.SpaceMasterAccess)]
     [ApiController]
     [Route("api/{teamName}/workstations/[action]")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
     public class WorkstationsController : SuperController
     {
         private readonly ApplicationDbContext _context;

--- a/Test/TestsController/ApiAccessControllerTests.cs
+++ b/Test/TestsController/ApiAccessControllerTests.cs
@@ -37,14 +37,23 @@ namespace Test.TestsController
         public void TestControllerClassAttributes()
         {
             ControllerReflection.ControllerInherits("SuperController");
-            var authAttribute = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(5);
+            var authAttribute = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(7);
             authAttribute.ElementAt(0).Roles.ShouldBe(null);
             authAttribute.ElementAt(0).Policy.ShouldBe(AccessCodes.Codes.AccessMasterAccess);
-            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenOrApiAttribute>(5);
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(5);
-            ControllerReflection.ClassExpectedAttribute<ApiControllerAttribute>(5);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenOrApiAttribute>(7);
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(7);
+            ControllerReflection.ClassExpectedAttribute<ApiControllerAttribute>(7);
+            var attribConsumes = ControllerReflection.ClassExpectedAttribute<ConsumesAttribute>(7);
+            attribConsumes.ElementAt(0).ContentTypes.ElementAt(0).ShouldBe("application/json");
+            attribConsumes.Count().ShouldBe(1);
+            attribConsumes.ElementAt(0).ContentTypes.Count.ShouldBe(1);
 
-            var route = ControllerReflection.ClassExpectedAttribute<RouteAttribute>(5);
+            var attribProduces = ControllerReflection.ClassExpectedAttribute<ProducesAttribute>(7);
+            attribProduces.ElementAt(0).ContentTypes.ElementAt(0).ShouldBe("application/json");
+            attribProduces.Count().ShouldBe(1);
+            attribProduces.ElementAt(0).ContentTypes.Count.ShouldBe(1);
+
+            var route = ControllerReflection.ClassExpectedAttribute<RouteAttribute>(7);
             route.ElementAt(0).Template.ShouldBe("api/{teamName}/access/[action]");
         }
 

--- a/Test/TestsController/ApiEquipmentControllerTests.cs
+++ b/Test/TestsController/ApiEquipmentControllerTests.cs
@@ -37,15 +37,25 @@ namespace Test.TestsController
         public void TestControllerClassAttributes()
         {
             ControllerReflection.ControllerInherits("SuperController");
-            var authAttribute = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(5);
+            var authAttribute = ControllerReflection.ClassExpectedAttribute<AuthorizeAttribute>(7);
             authAttribute.ElementAt(0).Roles.ShouldBe(null);
             authAttribute.ElementAt(0).Policy.ShouldBe(AccessCodes.Codes.EquipMasterAccess);
 
-            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenOrApiAttribute>(5);
-            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(5);
-            ControllerReflection.ClassExpectedAttribute<ApiControllerAttribute>(5);
+            ControllerReflection.ClassExpectedAttribute<AutoValidateAntiforgeryTokenOrApiAttribute>(7);
+            ControllerReflection.ClassExpectedAttribute<ControllerAttribute>(7);
+            ControllerReflection.ClassExpectedAttribute<ApiControllerAttribute>(7);
 
-            var route = ControllerReflection.ClassExpectedAttribute<RouteAttribute>(5);
+            var attribConsumes = ControllerReflection.ClassExpectedAttribute<ConsumesAttribute>(7);
+            attribConsumes.ElementAt(0).ContentTypes.ElementAt(0).ShouldBe("application/json");
+            attribConsumes.Count().ShouldBe(1);
+            attribConsumes.ElementAt(0).ContentTypes.Count.ShouldBe(1);
+
+            var attribProduces = ControllerReflection.ClassExpectedAttribute<ProducesAttribute>(7);
+            attribProduces.ElementAt(0).ContentTypes.ElementAt(0).ShouldBe("application/json");
+            attribProduces.Count().ShouldBe(1);
+            attribProduces.ElementAt(0).ContentTypes.Count.ShouldBe(1);
+
+            var route = ControllerReflection.ClassExpectedAttribute<RouteAttribute>(7);
             route.ElementAt(0).Template.ShouldBe("api/{teamName}/equipment/[action]");
         }
 


### PR DESCRIPTION
closes #1002 

Made it for both request and response content types for all actions on all api controllers. Could be controlled on a more finely-grained basis if necessary.