### PR TITLE
Update serilog with newer init method and also better log only pipeline requests

### DIFF
--- a/Keas.Jobs.Core/Keas.Jobs.Core.csproj
+++ b/Keas.Jobs.Core/Keas.Jobs.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="serilog.sinks.elasticsearch" Version="8.4.1" />
     <PackageReference Include="Serilog.Sinks.Stackify" Version="2.0.2" />

--- a/Keas.Mvc/Helpers/LogConfiguration.cs
+++ b/Keas.Mvc/Helpers/LogConfiguration.cs
@@ -46,14 +46,16 @@ namespace Keas.Mvc.Helpers
 
             // standard logger
             var logConfig = new LoggerConfiguration()
-                .MinimumLevel.Information() // TODO: would like to do debug here, but would need to set our own custom logging to Log.Debug()
+                .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                // .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning) // uncomment this to hide EF core general info logs
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .Enrich.WithExceptionDetails();
 
             // various sinks
             logConfig = logConfig
+                .WriteTo.Console()
                 .WriteToStackifyCustom()
                 .WriteToElasticSearchCustom();
 

--- a/Keas.Mvc/Helpers/LogConfiguration.cs
+++ b/Keas.Mvc/Helpers/LogConfiguration.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Serilog;
+using Serilog.Events;
 using Serilog.Exceptions;
 using Serilog.Sinks.Elasticsearch;
 using StackifyLib;
@@ -45,6 +46,9 @@ namespace Keas.Mvc.Helpers
 
             // standard logger
             var logConfig = new LoggerConfiguration()
+                .MinimumLevel.Information() // TODO: would like to do debug here, but would need to set our own custom logging to Log.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .Enrich.WithExceptionDetails();
 

--- a/Keas.Mvc/Keas.Mvc.csproj
+++ b/Keas.Mvc/Keas.Mvc.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="6.0.0" />
     <PackageReference Include="serilog.sinks.elasticsearch" Version="8.4.1" />
     <PackageReference Include="Serilog.Sinks.Stackify" Version="2.0.2" />
     <PackageReference Include="SpaCliMiddleware" Version="3.1.2" />

--- a/Keas.Mvc/Keas.Mvc.csproj
+++ b/Keas.Mvc/Keas.Mvc.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Exceptions" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="serilog.sinks.elasticsearch" Version="8.4.1" />
     <PackageReference Include="Serilog.Sinks.Stackify" Version="2.0.2" />
     <PackageReference Include="SpaCliMiddleware" Version="3.1.2" />

--- a/Keas.Mvc/Program.cs
+++ b/Keas.Mvc/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Serilog;
 
 namespace Keas.Mvc
 {
@@ -32,6 +33,7 @@ namespace Keas.Mvc
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .UseSerilog()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/Keas.Mvc/Startup.cs
+++ b/Keas.Mvc/Startup.cs
@@ -65,6 +65,8 @@ namespace Keas.Mvc
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddHttpContextAccessor();
+
             services.Configure<AuthSettings>(Configuration.GetSection("Authentication"));
             services.Configure<KfsApiSettings>(Configuration.GetSection("KfsApi"));
             services.Configure<BigfixSettings>(Configuration.GetSection("Bigfix"));
@@ -218,7 +220,7 @@ namespace Keas.Mvc
         {
             // setup logging
             LogConfiguration.Setup(Configuration);
-            app.ConfigureStackifyLogging(Configuration);
+            app.ConfigureStackifyLogging(Configuration); // TODO: do we need this?
             loggerFactory.AddSerilog();
 
             appLifetime.ApplicationStopped.Register(Log.CloseAndFlush);
@@ -253,6 +255,8 @@ namespace Keas.Mvc
                 app.UseStaticFiles();
                 app.UseHsts();
             }
+
+            app.UseSerilogRequestLogging();
 
             app.UseHttpsRedirection();
             app.UseRouting();

--- a/Keas.Mvc/Startup.cs
+++ b/Keas.Mvc/Startup.cs
@@ -220,7 +220,7 @@ namespace Keas.Mvc
         {
             // setup logging
             LogConfiguration.Setup(Configuration);
-            app.ConfigureStackifyLogging(Configuration); // TODO: do we need this?
+            app.ConfigureStackifyLogging(Configuration);
             loggerFactory.AddSerilog();
 
             appLifetime.ApplicationStopped.Register(Log.CloseAndFlush);


### PR DESCRIPTION
By default aspnet routing is very verbose.  Switch to using the serilog request logging stuff, see: https://github.com/serilog/serilog-aspnetcore#request-logging.