### PR TITLE
Don't allow person to be their own supervisor

### DIFF
--- a/Keas.Mvc/Controllers/Api/PeopleAdminController.cs
+++ b/Keas.Mvc/Controllers/Api/PeopleAdminController.cs
@@ -55,6 +55,11 @@ namespace Keas.Mvc.Controllers.Api
             //    return BadRequest("Supervisor not in team.");
             //}
 
+            if (person.SupervisorId == p.Id)
+            {
+                return BadRequest("Can't be their own supervisor");
+            }
+
             p.FirstName = person.FirstName;
             p.LastName = person.LastName;
             p.Email = person.Email;


### PR DESCRIPTION
My Previous fix in PR #1106 worked if the supervisor was null and you added yourself.
But... If you are already your own supervisor, and you edit your person record, you get an error again.

So... just don't allow a person to be their own supervisor.