### PR TITLE
Migrate RazorLight to Razor.Templating.Core

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,6 +37,24 @@
             }
         },
         {
+            "name": ".NET Core Launch (SendMail)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "buildSendMail",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/Keas.Jobs.SendMail/bin/Debug/netcoreapp3.1/Keas.Jobs.SendMail.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Keas.Jobs.SendMail",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,22 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "build",
+            "label": "build",
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
                 "${workspaceFolder}/Keas.Mvc/Keas.Mvc.csproj"
             ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "buildSendMail",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Keas.Jobs.SendMail/Keas.Jobs.SendMail.csproj"],
             "problemMatcher": "$msCompile"
         }
     ]

--- a/Keas.Core/Keas.Core.csproj
+++ b/Keas.Core/Keas.Core.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-      <TargetFramework>netstandard2.1</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
       <LangVersion>8.0</LangVersion>
   </PropertyGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App"/>
+	</ItemGroup>
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="2.8.26" />
     <PackageReference Include="libphonenumber-csharp" Version="8.12.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="RazorLight" Version="2.0.0-beta9" />
+    <PackageReference Include="Razor.Templating.Core" Version="1.6.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 </Project>

--- a/Keas.Core/Services/IEmailService.cs
+++ b/Keas.Core/Services/IEmailService.cs
@@ -11,7 +11,7 @@ using Keas.Core.Extensions;
 using Keas.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using RazorLight;
+using Razor.Templating.Core;
 using Serilog;
 using System.Net.Mail;
 using System.Net.Mime;
@@ -87,7 +87,7 @@ namespace Keas.Core.Services
                 // body is our fallback text and we'll add an HTML view as an alternate.
                 message.Body = "Your team has asset assignments that are expiring. Please visit https://peaks.ucdavis.edu to review them.";
 
-                var htmlView = AlternateView.CreateAlternateViewFromString(await GetRazorEngine().CompileRenderAsync("/EmailTemplates/_ExpiringTeam.cshtml", expiringItems), new ContentType(MediaTypeNames.Text.Html));
+                var htmlView = AlternateView.CreateAlternateViewFromString(await RazorTemplateEngine.RenderAsync("/EmailTemplates/_ExpiringTeam.cshtml", expiringItems), new ContentType(MediaTypeNames.Text.Html));
                 message.AlternateViews.Add(htmlView);
 
                 await _client.SendMailAsync(message);
@@ -137,7 +137,7 @@ namespace Keas.Core.Services
                 // body is our fallback text and we'll add an HTML view as an alternate.
                 message.Body = "Your team has asset assignments that are expiring. Please visit https://peaks.ucdavis.edu to review them.";
 
-                var htmlView = AlternateView.CreateAlternateViewFromString(await GetRazorEngine().CompileRenderAsync("/EmailTemplates/_ExpiringTeam.cshtml", expiringItems), new ContentType(MediaTypeNames.Text.Html));
+                var htmlView = AlternateView.CreateAlternateViewFromString(await RazorTemplateEngine.RenderAsync("/EmailTemplates/_ExpiringTeam.cshtml", expiringItems), new ContentType(MediaTypeNames.Text.Html));
                 message.AlternateViews.Add(htmlView);
 
                 await _client.SendMailAsync(message);
@@ -172,7 +172,7 @@ namespace Keas.Core.Services
                     // body is our fallback text and we'll add an HTML view as an alternate.
                     message.Body = "The people in your teams have changed";
 
-                    var htmlView = AlternateView.CreateAlternateViewFromString(await GetRazorEngine().CompileRenderAsync("/EmailTemplates/_Notification-person.cshtml", personNotifications), new ContentType(MediaTypeNames.Text.Html));
+                    var htmlView = AlternateView.CreateAlternateViewFromString(await RazorTemplateEngine.RenderAsync("/EmailTemplates/_Notification-person.cshtml", personNotifications), new ContentType(MediaTypeNames.Text.Html));
                     message.AlternateViews.Add(htmlView);
 
                     try
@@ -222,7 +222,7 @@ namespace Keas.Core.Services
                     // body is our fallback text and we'll add an HTML view as an alternate.
                     message.Body = "The people in your teams have changed";
 
-                    var htmlView = AlternateView.CreateAlternateViewFromString(await GetRazorEngine().CompileRenderAsync("/EmailTemplates/_Notification-person.cshtml", personNotifications), new ContentType(MediaTypeNames.Text.Html));
+                    var htmlView = AlternateView.CreateAlternateViewFromString(await RazorTemplateEngine.RenderAsync("/EmailTemplates/_Notification-person.cshtml", personNotifications), new ContentType(MediaTypeNames.Text.Html));
                     message.AlternateViews.Add(htmlView);
 
                     try
@@ -295,7 +295,7 @@ namespace Keas.Core.Services
                 // body is our fallback text and we'll add an HTML view as an alternate.
                 message.Body = BuildExpiringTextMessage(expiringItems);
 
-                var htmlView = AlternateView.CreateAlternateViewFromString(await GetRazorEngine().CompileRenderAsync("/EmailTemplates/_Expiring.cshtml", expiringItems), new ContentType(MediaTypeNames.Text.Html));
+                var htmlView = AlternateView.CreateAlternateViewFromString(await RazorTemplateEngine.RenderAsync("/EmailTemplates/_Expiring.cshtml", expiringItems), new ContentType(MediaTypeNames.Text.Html));
                 message.AlternateViews.Add(htmlView);
 
                 await _client.SendMailAsync(message);
@@ -331,7 +331,7 @@ namespace Keas.Core.Services
                 // body is our fallback text and we'll add an HTML view as an alternate.
                 message.Body = BuildExpiringTextMessage(expiringItems);
 
-                var htmlView = AlternateView.CreateAlternateViewFromString(await GetRazorEngine().CompileRenderAsync("/EmailTemplates/_Expiring.cshtml", expiringItems), new ContentType(MediaTypeNames.Text.Html));
+                var htmlView = AlternateView.CreateAlternateViewFromString(await RazorTemplateEngine.RenderAsync("/EmailTemplates/_Expiring.cshtml", expiringItems), new ContentType(MediaTypeNames.Text.Html));
                 message.AlternateViews.Add(htmlView);
 
                 await _client.SendMailAsync(message);
@@ -512,7 +512,7 @@ namespace Keas.Core.Services
                 // body is our fallback text and we'll add an HTML view as an alternate.
                 message.Body = BuildNotificationTextMessage(notifications.ToList());
 
-                var htmlView = AlternateView.CreateAlternateViewFromString(await GetRazorEngine().CompileRenderAsync("/EmailTemplates/_Notification.cshtml", notifications.ToList()), new ContentType(MediaTypeNames.Text.Html));
+                var htmlView = AlternateView.CreateAlternateViewFromString(await RazorTemplateEngine.RenderAsync("/EmailTemplates/_Notification.cshtml", notifications.ToList()), new ContentType(MediaTypeNames.Text.Html));
                 message.AlternateViews.Add(htmlView);
 
                 await _client.SendMailAsync(message);
@@ -541,7 +541,7 @@ namespace Keas.Core.Services
                 // body is our fallback text and we'll add an HTML view as an alternate.
                 message.Body = BuildNotificationTextMessage(notifications.ToList());
 
-                var htmlView = AlternateView.CreateAlternateViewFromString(await GetRazorEngine().CompileRenderAsync("/EmailTemplates/_Notification.cshtml", notifications.ToList()), new ContentType(MediaTypeNames.Text.Html));
+                var htmlView = AlternateView.CreateAlternateViewFromString(await RazorTemplateEngine.RenderAsync("/EmailTemplates/_Notification.cshtml", notifications.ToList()), new ContentType(MediaTypeNames.Text.Html));
                 message.AlternateViews.Add(htmlView);
 
                 await _client.SendMailAsync(message);
@@ -571,18 +571,6 @@ namespace Keas.Core.Services
                 .ToListAsync();
 
             return users;
-        }
-
-        private RazorLightEngine GetRazorEngine()
-        {
-            var path = Path.GetFullPath(".");
-
-            var engine = new RazorLightEngineBuilder()
-                .UseFileSystemProject(path)
-                .UseMemoryCachingProvider()
-                .Build();
-
-            return engine;
         }
     }
 }

--- a/Keas.Jobs.SendMail/Keas.Jobs.SendMail.csproj
+++ b/Keas.Jobs.SendMail/Keas.Jobs.SendMail.csproj
@@ -1,42 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <UserSecretsId>93abda06-2870-4006-81e8-1eecba3d977c</UserSecretsId>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyVersion>1.0.0.9</AssemblyVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="EmailTemplates\_ExpiringTeam.cshtml" />
-    <None Remove="EmailTemplates\_Notification-person.cshtml" />
-    <None Remove="EmailTemplates\_Notification.cshtml" />
-    <None Remove="EmailTemplates\_Test.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="EmailTemplates\_Expiring.cshtml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Include="EmailTemplates\_ExpiringTeam.cshtml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="EmailTemplates\_Notification-person.cshtml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Include="EmailTemplates\_Notification.cshtml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Include="EmailTemplates\_Test.cshtml">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.5" />


### PR DESCRIPTION
`Razor.Templating.Core` doesn't work with a netstandard library project, so I had to change the core project from `netstandard2.1` to `netcoreapp3.1`.