### PR TITLE
Add a link to the email footer to the website

### DIFF
--- a/Keas.Jobs.SendMail/EmailTemplates/_Notification.cshtml
+++ b/Keas.Jobs.SendMail/EmailTemplates/_Notification.cshtml
@@ -124,7 +124,11 @@
                                             </th>
                                         </tr>
                                     </tbody>
-                                </table><div class="footer text-center"><div><img src="https://peaks.ucdavis.edu/Images/peaksLogo.png" alt="" style="-ms-interpolation-mode:bicubic;clear:both;display:block;max-width:100%;outline:0;text-decoration:none;width:auto" /></div><hr /><div><p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">This email was automatically generated. Please do not reply to it, as the mailbox is not monitored.</p></div></div>
+                                </table><div class="footer text-center"><div><img src="https://peaks.ucdavis.edu/Images/peaksLogo.png" alt="" style="-ms-interpolation-mode:bicubic;clear:both;display:block;max-width:100%;outline:0;text-decoration:none;width:auto" /></div><hr />
+                                <div>
+                                  <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">This email was automatically generated. Please do not reply to it, as the mailbox is not monitored.</p>
+                                  <p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">PEAKS Website: <a href="https://peaks.ucdavis.edu/">https://peaks.ucdavis.edu/</a></p>
+                                </div></div>
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
Note! This was not generated from the foundation emails, it was manually added. Foundation Emails does not appear to work with the latest node.js

![image](https://user-images.githubusercontent.com/469010/197577865-ebc98004-9a88-4709-a362-641eff34acd3.png)
