### PR TITLE
Rh/add assignment from unassigned asset

### DIFF
--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentAssignmentValues.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentAssignmentValues.tsx
@@ -9,10 +9,10 @@ interface IProps {
 }
 
 const EquipmentAssignmentValues = (props: IProps) => {
-  if (!props.selectedEquipment || !props.selectedEquipment.assignment) {
+  if (!props.selectedEquipment) {
     return null;
   }
-  
+
   return (
     <div>
       <div className='row justify-content-between mt-5'>
@@ -21,7 +21,10 @@ const EquipmentAssignmentValues = (props: IProps) => {
           color='link'
           onClick={() => props.openUpdateModal(props.selectedEquipment)}
         >
-          <i className='fas fa-edit fa-xs' /> Update Assignment
+          <i className='fas fa-edit fa-xs' />{' '}
+          {!!props.selectedEquipment.assignment
+            ? 'Update Assignment'
+            : 'Assign Equipment'}
         </Button>
       </div>
       <div className='wrapperasset'>
@@ -31,7 +34,11 @@ const EquipmentAssignmentValues = (props: IProps) => {
             type='text'
             className='form-control'
             disabled={true}
-            value={props.selectedEquipment.assignment.person.name}
+            value={
+              !!props.selectedEquipment.assignment
+                ? props.selectedEquipment.assignment.person.name
+                : ''
+            }
           />
         </div>
         <div className='form-group'>
@@ -40,9 +47,13 @@ const EquipmentAssignmentValues = (props: IProps) => {
             type='text'
             className='form-control'
             disabled={true}
-            value={DateUtil.formatExpiration(
-              props.selectedEquipment.assignment.expiresAt
-            )}
+            value={
+              !!props.selectedEquipment.assignment
+                ? DateUtil.formatExpiration(
+                    props.selectedEquipment.assignment.expiresAt
+                  )
+                : ''
+            }
           />
         </div>
       </div>

--- a/Keas.Mvc/ClientApp/src/components/Keys/KeySerialAssignmentValues.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/KeySerialAssignmentValues.tsx
@@ -9,10 +9,7 @@ interface IProps {
 }
 
 const KeySerialAssignmentValues = (props: IProps) => {
-  if (
-    !props.selectedKeySerial ||
-    !props.selectedKeySerial.keySerialAssignment
-  ) {
+  if (!props.selectedKeySerial) {
     return null;
   }
 
@@ -24,7 +21,10 @@ const KeySerialAssignmentValues = (props: IProps) => {
           color='link'
           onClick={() => props.openUpdateModal(props.selectedKeySerial)}
         >
-          <i className='fas fa-edit fa-xs' /> Update Assignment
+          <i className='fas fa-edit fa-xs' />{' '}
+          {!!props.selectedKeySerial.keySerialAssignment
+            ? 'Update Assignment'
+            : 'Assign Key'}
         </Button>
       </div>
       <div className='wrapperasset'>
@@ -34,7 +34,11 @@ const KeySerialAssignmentValues = (props: IProps) => {
             type='text'
             className='form-control'
             disabled={true}
-            value={props.selectedKeySerial.keySerialAssignment.person.name}
+            value={
+              !!props.selectedKeySerial.keySerialAssignment
+                ? props.selectedKeySerial.keySerialAssignment.person.name
+                : ''
+            }
           />
         </div>
         <div className='form-group'>
@@ -43,9 +47,13 @@ const KeySerialAssignmentValues = (props: IProps) => {
             type='text'
             className='form-control'
             disabled={true}
-            value={DateUtil.formatExpiration(
-              props.selectedKeySerial.keySerialAssignment.expiresAt
-            )}
+            value={
+              !!props.selectedKeySerial.keySerialAssignment
+                ? DateUtil.formatExpiration(
+                    props.selectedKeySerial.keySerialAssignment.expiresAt
+                  )
+                : ''
+            }
           />
         </div>
       </div>

--- a/Keas.Mvc/ClientApp/src/components/Keys/KeySerialAssignmentValues.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/KeySerialAssignmentValues.tsx
@@ -24,7 +24,7 @@ const KeySerialAssignmentValues = (props: IProps) => {
           <i className='fas fa-edit fa-xs' />{' '}
           {!!props.selectedKeySerial.keySerialAssignment
             ? 'Update Assignment'
-            : 'Assign Key'}
+            : 'Assign Key Serial'}
         </Button>
       </div>
       <div className='wrapperasset'>

--- a/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationAssignmentValues.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationAssignmentValues.tsx
@@ -9,24 +9,22 @@ interface IProps {
 }
 
 const WorkstationAssignmentValues = (props: IProps) => {
-  if (
-    !props.selectedWorkstation ||
-    !props.selectedWorkstation.assignment
-  ) {
+  if (!props.selectedWorkstation) {
     return null;
   }
-  
+
   return (
     <div>
       <div className='row justify-content-between mt-5'>
         <h3>Assignment Details</h3>
         <Button
           color='link'
-          onClick={() =>
-            props.openUpdateModal(props.selectedWorkstation)
-          }
+          onClick={() => props.openUpdateModal(props.selectedWorkstation)}
         >
-          <i className='fas fa-edit fa-xs' /> Update Assignment
+          <i className='fas fa-edit fa-xs' />{' '}
+          {!!props.selectedWorkstation.assignment
+            ? 'Update Assignment'
+            : 'Assign Workstation'}
         </Button>
       </div>
 
@@ -37,7 +35,11 @@ const WorkstationAssignmentValues = (props: IProps) => {
             type='text'
             className='form-control'
             disabled={true}
-            value={props.selectedWorkstation.assignment.person.name}
+            value={
+              !!props.selectedWorkstation.assignment
+                ? props.selectedWorkstation.assignment.person.name
+                : ''
+            }
           />
         </div>
         <div className='form-group'>
@@ -46,9 +48,13 @@ const WorkstationAssignmentValues = (props: IProps) => {
             type='text'
             className='form-control'
             disabled={true}
-            value={DateUtil.formatExpiration(
-              props.selectedWorkstation.assignment.expiresAt
-            )}
+            value={
+              !!props.selectedWorkstation.assignment
+                ? DateUtil.formatExpiration(
+                    props.selectedWorkstation.assignment.expiresAt
+                  )
+                : ''
+            }
           />
         </div>
       </div>


### PR DESCRIPTION
closes #1265 

always shows assignment details, links to assign modal so you can update without closing 

![image](https://github.com/ucdavis/Peaks/assets/27025973/5042bde2-ff39-4b51-b924-b1d9a1c64bd6)
