### PR TITLE
Rh/dialog actions

### DIFF
--- a/Keas.Mvc/ClientApp/src/components/Access/AccessModal.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Access/AccessModal.tsx
@@ -17,6 +17,7 @@ const AccessModal: React.FunctionComponent<IProps> = (
       toggle={props.closeModal}
       size='lg'
       className='access-color'
+      scrollable={true}
     >
       <div className='modal-header row justify-content-between'>
         {props.header}

--- a/Keas.Mvc/ClientApp/src/components/Access/AssignAccess.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Access/AssignAccess.tsx
@@ -139,6 +139,7 @@ const AssignAccess = (props: IProps) => {
       toggle={confirmClose}
       size='lg'
       className='access-color'
+      scrollable={!!access && !!access.teamId} // will be false when we are creating a new access
     >
       <div className='modal-header row justify-content-between'>
         <h2>

--- a/Keas.Mvc/ClientApp/src/components/Access/DeleteAccess.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Access/DeleteAccess.tsx
@@ -46,6 +46,7 @@ const DeleteAccess = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='access-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Delete {props.selectedAccess.name}</h2>

--- a/Keas.Mvc/ClientApp/src/components/Access/EditAccess.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Access/EditAccess.tsx
@@ -74,6 +74,7 @@ const EditAccess = (props: IProps) => {
       toggle={confirmClose}
       size='lg'
       className='access-color'
+      scrollable={true}
     >
       <div className='modal-header row justify-content-between'>
         <h2>Edit Access</h2>

--- a/Keas.Mvc/ClientApp/src/components/Documents/AssignDocument.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Documents/AssignDocument.tsx
@@ -99,6 +99,7 @@ export const AssignDocument = (props: IProps): JSX.Element => {
         toggle={() => setShow(false)}
         size='lg'
         className='documents-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Assign Document for Signature</h2>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/AssignEquipment.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/AssignEquipment.tsx
@@ -151,6 +151,7 @@ const AssignEquipment = (props: IProps) => {
       toggle={confirmClose}
       size='lg'
       className='equipment-color'
+      scrollable={!!equipment && !!equipment.teamId} // will be false when we are creating a new equipment
     >
       <div className='modal-header row justify-content-between'>
         <h2>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/DeleteEquipment.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/DeleteEquipment.tsx
@@ -48,6 +48,7 @@ const DeleteEquipment = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='equipment-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Delete {props.selectedEquipment.name}</h2>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EditEquipment.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EditEquipment.tsx
@@ -104,6 +104,7 @@ const EditEquipment = (props: IProps) => {
       toggle={confirmClose}
       size='lg'
       className='equipment-color'
+      scrollable={true}
     >
       <div className='modal-header row justify-content-between'>
         <h2>Edit Equipment</h2>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentManagedSystemInfo.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentManagedSystemInfo.tsx
@@ -38,7 +38,6 @@ const EquipmentManagedSystemInfo = (props: IProps) => {
         toggle={modalToggle}
         size='lg'
         className='equipment-color'
-        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Computer Details</h2>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentManagedSystemInfo.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentManagedSystemInfo.tsx
@@ -38,6 +38,7 @@ const EquipmentManagedSystemInfo = (props: IProps) => {
         toggle={modalToggle}
         size='lg'
         className='equipment-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Computer Details</h2>
@@ -90,7 +91,8 @@ const EquipmentManagedSystemInfo = (props: IProps) => {
       } else {
         return (
           <p>
-            Not a valid Managed System id, please make sure to enter a valid Managed System id.
+            Not a valid Managed System id, please make sure to enter a valid
+            Managed System id.
           </p>
         );
       }

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentManagedSystemSearchId.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentManagedSystemSearchId.tsx
@@ -52,6 +52,7 @@ const EquipmentManagedSystemSearchId = (props: IProps) => {
         toggle={modalToggle}
         size='lg'
         className='equipment-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Search by Computer Property</h2>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/RevokeEquipment.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/RevokeEquipment.tsx
@@ -45,6 +45,7 @@ const RevokeEquipment = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='equipment-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Revoke {props.selectedEquipment.name}</h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/AssignKeySerial.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/AssignKeySerial.tsx
@@ -153,6 +153,7 @@ const AssignKeySerial = (props: IProps) => {
       toggle={confirmClose}
       size='lg'
       className='keys-color'
+      scrollable={!!keySerial && !!keySerial.id} // will be false when we are creating a new key serial
     >
       <div className='modal-header row justify-content-between'>
         <h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/AssociateSpace.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/AssociateSpace.tsx
@@ -188,6 +188,7 @@ const AssociateSpace = (props: IProps) => {
       toggle={closeModal}
       size='lg'
       className='keys-color'
+      scrollable={true}
     >
       <div className='modal-header row justify-content-between'>
         <h2>Assign Key</h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/CreateKey.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/CreateKey.tsx
@@ -54,6 +54,7 @@ const CreateKey = (props: IProps) => {
         toggle={confirmClose}
         size='lg'
         className='keys-color'
+        scrollable={false}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Create Key</h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/DeleteKey.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/DeleteKey.tsx
@@ -45,6 +45,7 @@ const DeleteKey = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='keys-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Delete {props.selectedKeyInfo.key.name}</h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/DisassociateSpace.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/DisassociateSpace.tsx
@@ -45,6 +45,7 @@ const DisassociateSpace = (props: IProps) => {
         toggle={closeModal}
         size='lg'
         className='keys-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Disassociate Key and Space</h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/EditKey.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/EditKey.tsx
@@ -43,7 +43,7 @@ const EditKey = (props: IProps) => {
 
   const { searchableTags } = props;
   const changeProperty = (property: string, value: string) => {
-    setKey({...key, [property]: value})
+    setKey({ ...key, [property]: value });
   };
 
   // clear everything out on close
@@ -86,6 +86,7 @@ const EditKey = (props: IProps) => {
       toggle={confirmClose}
       size='lg'
       className='keys-color'
+      scrollable={true}
     >
       <div className='modal-header row justify-content-between'>
         <h2>Edit Key</h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/EditKeySerial.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/EditKeySerial.tsx
@@ -93,6 +93,7 @@ const EditKeySerial = (props: IProps) => {
       toggle={confirmClose}
       size='lg'
       className='keys-color'
+      scrollable={true}
     >
       <div className='modal-header row justify-content-between'>
         <h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
@@ -63,7 +63,6 @@ const KeySerialDetails = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='keys-color'
-        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
@@ -24,11 +24,11 @@ const KeySerialDetails = (props: IProps) => {
   const { selectedKeySerial } = props;
 
   useEffect(() => {
-      if (!props.selectedKeySerial) {
-        return;
-      }
-      fetchDetails(props.selectedKeySerial.id);
-  }, [])
+    if (!props.selectedKeySerial) {
+      return;
+    }
+    fetchDetails(props.selectedKeySerial.id);
+  }, []);
 
   if (!selectedKeySerial) {
     return null;
@@ -63,6 +63,7 @@ const KeySerialDetails = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='keys-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>

--- a/Keas.Mvc/ClientApp/src/components/Keys/RevokeKeySerial.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/RevokeKeySerial.tsx
@@ -54,6 +54,7 @@ const RevokeKeySerial = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='keys-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>

--- a/Keas.Mvc/ClientApp/src/components/People/CreatePerson.tsx
+++ b/Keas.Mvc/ClientApp/src/components/People/CreatePerson.tsx
@@ -143,6 +143,7 @@ const CreatePerson = (props: IProps) => {
         toggle={confirmClose}
         size='lg'
         className='people-color'
+        scrollable={false}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Add Person</h2>

--- a/Keas.Mvc/ClientApp/src/components/People/DeletePerson.tsx
+++ b/Keas.Mvc/ClientApp/src/components/People/DeletePerson.tsx
@@ -48,20 +48,21 @@ const DeletePerson = (props: IProps) => {
 
   return (
     <div>
-      <Button color="link" onClick={toggleModal}>
-        <i className="fas fa-trash fa-sm fa-fw mr-2" aria-hidden="true" />
+      <Button color='link' onClick={toggleModal}>
+        <i className='fas fa-trash fa-sm fa-fw mr-2' aria-hidden='true' />
         Delete Person
       </Button>
       <Modal
         isOpen={modal}
         toggle={toggleModal}
-        size="lg"
-        className="people-color"
+        size='lg'
+        className='people-color'
+        scrollable={true}
       >
-        <div className="modal-header row justify-content-between">
+        <div className='modal-header row justify-content-between'>
           <h2>Delete {props.selectedPersonInfo.person.name}</h2>
-          <Button color="link" onClick={toggleModal}>
-            <i className="fas fa-times fa-lg" />
+          <Button color='link' onClick={toggleModal}>
+            <i className='fas fa-times fa-lg' />
           </Button>
         </div>
 
@@ -80,11 +81,11 @@ const DeletePerson = (props: IProps) => {
         </ModalBody>
         <ModalFooter>
           <Button
-            color="primary"
+            color='primary'
             onClick={deletePerson}
             disabled={submitting || !checkValidToDelete()}
           >
-            Go! {submitting && <i className="fas fa-circle-notch fa-spin" />}
+            Go! {submitting && <i className='fas fa-circle-notch fa-spin' />}
           </Button>{' '}
         </ModalFooter>
       </Modal>

--- a/Keas.Mvc/ClientApp/src/components/People/EditPerson.tsx
+++ b/Keas.Mvc/ClientApp/src/components/People/EditPerson.tsx
@@ -101,6 +101,7 @@ const EditPerson = (props: IProps) => {
         toggle={confirmClose}
         size='lg'
         className='people-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Edit Person</h2>

--- a/Keas.Mvc/ClientApp/src/components/Workstations/AssignWorkstation.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/AssignWorkstation.tsx
@@ -132,6 +132,7 @@ const AssignWorkstation = (props: IProps) => {
         toggle={confirmClose}
         size='lg'
         className='spaces-color'
+        scrollable={!!workstation && !!workstation.teamId} // will be false if we are creating a new workstation
       >
         <div className='modal-header row justify-content-between'>
           <h2>

--- a/Keas.Mvc/ClientApp/src/components/Workstations/DeleteWorkstation.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/DeleteWorkstation.tsx
@@ -45,6 +45,7 @@ const DeleteWorkstation = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='workstation-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Delete {props.selectedWorkstation.name}</h2>

--- a/Keas.Mvc/ClientApp/src/components/Workstations/EditWorkstation.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/EditWorkstation.tsx
@@ -87,6 +87,7 @@ const EditWorkstation = (props: IProps) => {
       toggle={confirmClose}
       size='lg'
       className='spaces-color'
+      scrollable={true}
     >
       <div className='modal-header row justify-content-between'>
         <h2>Edit Workstation</h2>

--- a/Keas.Mvc/ClientApp/src/components/Workstations/RevokeWorkstation.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/RevokeWorkstation.tsx
@@ -40,6 +40,7 @@ const RevokeWorkstation = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='spaces-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Revoke {props.selectedWorkstation.name}</h2>

--- a/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
@@ -61,6 +61,7 @@ const WorkstationDetails = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='spaces-color'
+        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Details for {workstation.name}</h2>

--- a/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
@@ -61,7 +61,6 @@ const WorkstationDetails = (props: IProps) => {
         toggle={props.closeModal}
         size='lg'
         className='spaces-color'
-        scrollable={true}
       >
         <div className='modal-header row justify-content-between'>
           <h2>Details for {workstation.name}</h2>


### PR DESCRIPTION
closes #1259 

adds sticky footer with dialog actions on all modals that have it, except when we are creating a new asset (so the user has to look at all the fields). does not affect details pages. 

@cydoval some modals occasionally have a small amount of horizontal scroll, is that something you want to fix? 

![image](https://github.com/ucdavis/Peaks/assets/27025973/cef4aecf-ec40-456a-9b80-350440e22f4c)
![image](https://github.com/ucdavis/Peaks/assets/27025973/cb29630a-6ec8-42af-952a-7f3e2e95ac55)
