### PR TITLE
Rh/duplicate equip

### DIFF
--- a/Keas.Mvc/ClientApp/src/components/Equipment/DuplicateEquipment.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/DuplicateEquipment.tsx
@@ -186,21 +186,20 @@ const DuplicateEquipment = (props: IProps) => {
                 onChangeDate={changeDate}
               />
             )}
-            {equipment && !equipment.teamId && (
-              <div>
-                <EquipmentEditValues
-                  selectedEquipment={equipment}
-                  commonAttributeKeys={props.commonAttributeKeys}
-                  changeProperty={changeProperty}
-                  disableEditing={false}
-                  updateAttributes={updateAttributes}
-                  space={props.space}
-                  tags={props.tags}
-                  equipmentTypes={props.equipmentTypes}
-                  error={error}
-                />
-              </div>
-            )}
+            <div>
+              <EquipmentEditValues
+                selectedEquipment={equipment}
+                commonAttributeKeys={props.commonAttributeKeys}
+                changeProperty={changeProperty}
+                disableEditing={false}
+                updateAttributes={updateAttributes}
+                space={props.space}
+                tags={props.tags}
+                equipmentTypes={props.equipmentTypes}
+                error={error}
+                duplicate={true}
+              />
+            </div>
           </Form>
         </div>
       </ModalBody>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/DuplicateEquipment.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/DuplicateEquipment.tsx
@@ -13,14 +13,15 @@ import { ISpace } from '../../models/Spaces';
 import AssignPerson from '../People/AssignPerson';
 import AssignDate from '../Shared/AssignDate';
 import EquipmentEditValues from './EquipmentEditValues';
-import SearchEquipment from './SearchEquipment';
 
 interface IProps {
-  onCreate: (person: IPerson, equipment: IEquipment, date: any) => void;
+  onDuplicate: (
+    person: IPerson,
+    equipment: IEquipment,
+    date: any,
+    duplicate?: boolean
+  ) => void;
   modal: boolean;
-  onAddNew: () => void;
-  openDetailsModal: (equipment: IEquipment) => void;
-  openEditModal: (equipment: IEquipment) => void;
   closeModal: () => void;
   selectedEquipment: IEquipment;
   person?: IPerson;
@@ -30,34 +31,47 @@ interface IProps {
   equipmentTypes: string[];
 }
 
-const AssignEquipment = (props: IProps) => {
+const DuplicateEquipment = (props: IProps) => {
   // if we are on the person page, we use that person and don't allow changing it
-  // if we are creating, we initialize with a new object, a new date, and no person (unless we are on the person page)
-  // if we are assigning, we initialize with the selected asset, a new date and the person from the assignment
-  // if we are updating an assignment, we initialize with the selected asset, the date of the assignment, and the person from the assignment
-  const [date, setDate] = useState<Date>(
-    !!props.selectedEquipment && !!props.selectedEquipment.assignment
-      ? new Date(props.selectedEquipment.assignment.expiresAt)
-      : addYears(startOfDay(new Date()), 3)
-  );
-  const [equipment, setEquipment] = useState<IEquipment>(
-    props.selectedEquipment
-  );
+  // if we are duplicating an assignment, we initialize with the selected asset, a new date, and no person (unless we are on the person page)
   const [error, setError] = useState<IValidationError>({
     message: '',
     path: ''
   });
-  const [person, setPerson] = useState<IPerson>(
-    !!props.selectedEquipment && !!props.selectedEquipment.assignment
-      ? props.selectedEquipment.assignment.person
-      : props.person
-  );
+  const [date, setDate] = useState<Date>(addYears(startOfDay(new Date()), 3));
+  const [equipment, setEquipment] = useState<IEquipment>(() => {
+    // copy the selected equipment but clear unique fields
+    if (!!props.selectedEquipment) {
+      // equip may not be loaded yet
+      return {
+        attributes: props.selectedEquipment.attributes.map(a => {
+          return { ...a, equipmentId: 0, id: 0 };
+        }),
+        availabilityLevel: props.selectedEquipment.availabilityLevel,
+        id: 0,
+        make: props.selectedEquipment.make,
+        model: props.selectedEquipment.model,
+        name: props.selectedEquipment.name,
+        notes: props.selectedEquipment.notes,
+        protectionLevel: props.selectedEquipment.protectionLevel,
+        serialNumber: '', // serial number is not duplicated
+        space: props.selectedEquipment.space,
+        systemManagementId: '', // system management id is not duplicated
+        tags: props.selectedEquipment.tags,
+        teamId: 0,
+        type: props.selectedEquipment.type
+      };
+    }
+    return null;
+  });
+  const [person, setPerson] = useState<IPerson>(props.person);
+
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [validState, setValidState] = useState<boolean>(false);
 
   useEffect(() => {
     const validateState = () => {
-      const error = yupAssetValidation(
+      let error = yupAssetValidation(
         equipmentSchema,
         equipment,
         {}, // no context
@@ -68,7 +82,7 @@ const AssignEquipment = (props: IProps) => {
     };
 
     validateState();
-  }, [date, equipment, person]);
+  }, [date, equipment, person, props.selectedEquipment]);
 
   const changeProperty = (property: string, value: string) => {
     setEquipment({ ...equipment, [property]: value });
@@ -110,31 +124,18 @@ const AssignEquipment = (props: IProps) => {
     const personData = props.person ? props.person : person;
     const equipmentData = equipment;
     equipmentData.attributes = equipmentData.attributes.filter(x => !!x.key);
-
     try {
-      await props.onCreate(
+      await props.onDuplicate(
         personData,
         equipmentData,
-        format(date, 'MM/dd/yyyy')
+        format(date, 'MM/dd/yyyy'),
+        true
       );
     } catch (e) {
       setSubmitting(false);
       return;
     }
     closeModal();
-  };
-
-  // once we have either selected or created the equipment we care about
-  const onSelected = (selectedEquipment: IEquipment) => {
-    setEquipment(selectedEquipment);
-  };
-
-  const onDeselected = () => {
-    setEquipment(null);
-    setError({
-      message: '',
-      path: ''
-    });
   };
 
   const onSelectPerson = (selectedPerson: IPerson) => {
@@ -158,11 +159,7 @@ const AssignEquipment = (props: IProps) => {
       scrollable={!!equipment && !!equipment.teamId} // will be false when we are creating a new equipment
     >
       <div className='modal-header row justify-content-between'>
-        <h2>
-          {props.selectedEquipment || props.person
-            ? 'Assign Equipment'
-            : 'Add Equipment'}
-        </h2>
+        <h2>Duplicate Equipment</h2>
         <Button color='link' onClick={closeModal}>
           <i className='fas fa-times fa-lg' />
         </Button>
@@ -174,12 +171,11 @@ const AssignEquipment = (props: IProps) => {
               person={person}
               label='Assign To'
               onSelect={onSelectPerson}
-              isRequired={equipment && equipment.teamId !== 0}
+              isRequired={equipment && equipment.teamId !== 0} //teamId is 0 on create or dupe
               disabled={
-                !!props.person ||
-                (!!props.selectedEquipment &&
-                  !!props.selectedEquipment.assignment)
-              } // disable if we are on person page or updating
+                !!props.person || //if on person page
+                (!!equipment && !!equipment.assignment) // if updating currently assigned (taken care of in initial state)
+              }
               error={error}
             />
             {(!!person || !!props.person) && (
@@ -190,57 +186,17 @@ const AssignEquipment = (props: IProps) => {
                 onChangeDate={changeDate}
               />
             )}
-            {!equipment && (
-              <div className='form-group'>
-                <SearchEquipment
-                  selectedEquipment={equipment}
-                  onSelect={onSelected}
-                  onDeselect={onDeselected}
-                  space={props.space}
-                  openDetailsModal={props.openDetailsModal}
-                />
-              </div>
-            )}
-            {equipment &&
-            !equipment.teamId && ( // if we are creating a new equipment, edit properties
-                <div>
-                  <div className='row justify-content-between'>
-                    <h3>Create New Equipment</h3>
-                    <Button color='link' onClick={onDeselected}>
-                      Clear{' '}
-                      <i className='fas fa-times fa-sm' aria-hidden='true' />
-                    </Button>
-                  </div>
-
-                  <EquipmentEditValues
-                    selectedEquipment={equipment}
-                    commonAttributeKeys={props.commonAttributeKeys}
-                    changeProperty={changeProperty}
-                    disableEditing={false}
-                    updateAttributes={updateAttributes}
-                    space={props.space}
-                    tags={props.tags}
-                    equipmentTypes={props.equipmentTypes}
-                    error={error}
-                  />
-                </div>
-              )}
-            {equipment && !!equipment.teamId && (
+            {equipment && !equipment.teamId && (
               <div>
-                <div className='row justify-content-between'>
-                  <h3>Assign Existing Equipment</h3>
-                  <Button color='link' onClick={onDeselected}>
-                    Clear{' '}
-                    <i className='fas fa-times fa-sm' aria-hidden='true' />
-                  </Button>
-                </div>
-
                 <EquipmentEditValues
                   selectedEquipment={equipment}
                   commonAttributeKeys={props.commonAttributeKeys}
-                  disableEditing={true}
-                  openEditModal={props.openEditModal}
+                  changeProperty={changeProperty}
+                  disableEditing={false}
+                  updateAttributes={updateAttributes}
+                  space={props.space}
                   tags={props.tags}
+                  equipmentTypes={props.equipmentTypes}
                   error={error}
                 />
               </div>
@@ -261,4 +217,4 @@ const AssignEquipment = (props: IProps) => {
   );
 };
 
-export default AssignEquipment;
+export default DuplicateEquipment;

--- a/Keas.Mvc/ClientApp/src/components/Equipment/DuplicateEquipment.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/DuplicateEquipment.tsx
@@ -186,20 +186,32 @@ const DuplicateEquipment = (props: IProps) => {
                 onChangeDate={changeDate}
               />
             )}
-            <div>
+            {!!equipment && !equipment.teamId && (
+              <div>
+                <EquipmentEditValues
+                  selectedEquipment={equipment}
+                  commonAttributeKeys={props.commonAttributeKeys}
+                  changeProperty={changeProperty}
+                  disableEditing={false}
+                  updateAttributes={updateAttributes}
+                  space={props.space}
+                  tags={props.tags}
+                  equipmentTypes={props.equipmentTypes}
+                  error={error}
+                  duplicate={true}
+                />
+              </div>
+            )}
+            {!!equipment && !!equipment.teamId && (
+              // this is just for once user hits "Go!"
               <EquipmentEditValues
                 selectedEquipment={equipment}
                 commonAttributeKeys={props.commonAttributeKeys}
-                changeProperty={changeProperty}
-                disableEditing={false}
-                updateAttributes={updateAttributes}
-                space={props.space}
+                disableEditing={true}
                 tags={props.tags}
-                equipmentTypes={props.equipmentTypes}
                 error={error}
-                duplicate={true}
               />
-            </div>
+            )}
           </Form>
         </div>
       </ModalBody>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentContainer.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentContainer.tsx
@@ -298,7 +298,11 @@ const EquipmentContainer = (props: IProps): JSX.Element => {
           body: JSON.stringify(selectedEquipment),
           method: 'POST'
         });
-        toast.success('Equipment created successfully!');
+        toast.success(
+          !!duplicate
+            ? 'Equipment duplicated successfully!'
+            : 'Equipment created successfully!'
+        );
       } catch (err) {
         const errorMessage =
           err.message === ''

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentEditValues.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentEditValues.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Button, FormFeedback, FormGroup, Input, Label } from 'reactstrap';
+import {
+  Button,
+  FormFeedback,
+  FormGroup,
+  FormText,
+  Input,
+  Label
+} from 'reactstrap';
 import { IEquipment, IEquipmentAttribute } from '../../models/Equipment';
 import { IValidationError } from '../../models/Shared';
 import { ISpace } from '../../models/Spaces';
@@ -19,6 +26,7 @@ interface IProps {
   updateAttributes?: (attribute: IEquipmentAttribute[]) => void;
   openEditModal?: (equipment: IEquipment) => void; // if disableEditing is true, this needs to be supplied
   error?: IValidationError;
+  duplicate?: boolean;
 }
 
 const EquipmentEditValues = (props: IProps) => {
@@ -145,6 +153,9 @@ const EquipmentEditValues = (props: IProps) => {
           <FormFeedback>
             {error && error.path === 'name' && error.message}
           </FormFeedback>
+          {props.duplicate && (
+            <FormText>Serial Number is not duplicated.</FormText>
+          )}
         </FormGroup>
         {shouldShowForType(
           props.selectedEquipment.type,
@@ -272,6 +283,9 @@ const EquipmentEditValues = (props: IProps) => {
             <FormFeedback>
               {error && error.path === 'systemManagementId' && error.message}
             </FormFeedback>
+            {props.duplicate && (
+              <FormText>System Management ID is not duplicated.</FormText>
+            )}
           </FormGroup>
         )}
         <FormGroup>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentList.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentList.tsx
@@ -9,6 +9,7 @@ interface IProps {
   onAdd?: (equipment: IEquipment) => void;
   showDetails?: (equipment: IEquipment) => void;
   onEdit?: (equipment: IEquipment) => void;
+  onDuplicate?: (equipment: IEquipment) => void;
 }
 
 const EquipmentList = (props: IProps) => {
@@ -27,6 +28,7 @@ const EquipmentList = (props: IProps) => {
           onAdd={props.onAdd}
           showDetails={props.showDetails}
           onEdit={props.onEdit}
+          onDuplicate={props.onDuplicate}
         />
       ))
     );

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentListItem.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentListItem.tsx
@@ -11,6 +11,7 @@ interface IProps {
   onAdd?: (equipment: IEquipment) => void;
   showDetails?: (equipment: IEquipment) => void;
   onEdit?: (equipment: IEquipment) => void;
+  onDuplicate?: (equipment: IEquipment) => void;
 }
 
 const EquipmentListItem = (props: IProps) => {
@@ -35,6 +36,13 @@ const EquipmentListItem = (props: IProps) => {
     actions.push({
       onClick: () => props.onDelete(props.equipmentEntity),
       title: 'Delete'
+    });
+  }
+
+  if (!!props.onDuplicate) {
+    actions.push({
+      onClick: () => props.onDuplicate(props.equipmentEntity),
+      title: 'Duplicate'
     });
   }
 

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentTable.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentTable.tsx
@@ -18,6 +18,7 @@ interface IProps {
   onAdd?: (equipment: IEquipment) => void;
   showDetails?: (equipment: IEquipment) => void;
   onEdit?: (equipment: IEquipment) => void;
+  onDuplicate?: (equipment: IEquipment) => void;
 }
 
 const EquipmentTable = (props: IProps) => {
@@ -45,6 +46,13 @@ const EquipmentTable = (props: IProps) => {
       actions.push({
         onClick: () => props.onDelete(equipmentEntity),
         title: 'Delete'
+      });
+    }
+
+    if (!!props.onDuplicate) {
+      actions.push({
+        onClick: () => props.onDuplicate(equipmentEntity),
+        title: 'Duplicate'
       });
     }
 

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentTableContainer.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentTableContainer.tsx
@@ -17,6 +17,7 @@ interface IProps {
   openAssignModal?: (equipment: IEquipment) => void;
   openDetailsModal?: (equipment: IEquipment) => void;
   openEditModal?: (equipment: IEquipment) => void;
+  openDuplicateModal?: (equipment: IEquipment) => void;
 }
 
 const EquipmentTableContainer = (props: IProps) => {
@@ -258,6 +259,7 @@ const EquipmentTableContainer = (props: IProps) => {
         onAdd={props.openAssignModal}
         showDetails={props.openDetailsModal}
         onEdit={props.openEditModal}
+        onDuplicate={props.openDuplicateModal}
       />
     </div>
   );

--- a/Keas.Mvc/ClientApp/src/components/Equipment/SearchEquipment.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/SearchEquipment.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useContext, useState } from 'react';
-import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead';
+import { Highlighter } from 'react-bootstrap-typeahead';
 import { toast } from 'react-toastify';
 import { Button } from 'reactstrap';
 import { Context } from '../../Context';

--- a/Keas.Mvc/Services/EventService.cs
+++ b/Keas.Mvc/Services/EventService.cs
@@ -14,6 +14,7 @@ namespace Keas.Mvc.Services
         Task TrackAssignEquipment(Equipment equipment);
         Task TrackUnAssignEquipment(Equipment equipment);
         Task TrackUpdateEquipment(Equipment equipment);
+        Task TrackDuplicateEquipment(Equipment equipment);
         Task TrackCreateAccess(Access access);
         Task TrackAssignAccess(AccessAssignment accessAssignment, string teamName);
         Task TrackAssignAccessUpdate(AccessAssignment accessAssignment, string teamName);
@@ -109,7 +110,11 @@ namespace Keas.Mvc.Services
             var history = await _historyService.EquipmentUpdated(equipment);
             await _notificationService.EquipmentCreatedUpdatedInactive(equipment, history);
         }
-
+        public async Task TrackDuplicateEquipment(Equipment equipment)
+        {
+            var history = await _historyService.EquipmentDuplicated(equipment);
+            await _notificationService.EquipmentCreatedUpdatedInactive(equipment, history);
+        }
 
         public async Task TrackCreateAccess(Access access)
         {

--- a/Keas.Mvc/Services/HistoryService.cs
+++ b/Keas.Mvc/Services/HistoryService.cs
@@ -15,6 +15,7 @@ namespace Keas.Mvc.Services
         Task<History> KeySerialCreated(KeySerial keySerial);
         Task<History> AccessCreated(Access access);
         Task<History> EquipmentCreated(Equipment equipment);
+        Task<History> EquipmentDuplicated(Equipment equipment);
         Task<History> KeyUpdated(Key key);
         Task<History> KeySerialUpdated(KeySerial keySerial);
         Task<History> AccessUpdated(Access access);
@@ -121,6 +122,21 @@ namespace Keas.Mvc.Services
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Created",
+                Equipment = equipment,
+            };
+            _context.Histories.Add(historyEntry);
+            return historyEntry;
+        }
+
+        public async Task<History> EquipmentDuplicated(Equipment equipment)
+        {
+            var person = await _securityService.GetPerson(equipment.TeamId);
+            var historyEntry = new History
+            {
+                Description = equipment.GetDescription(nameof(Equipment), equipment.Title, person, "Created as a copy of an existing asset"),
+                ActorId = person.UserId,
+                AssetType = "Equipment",
+                ActionType = "Duplicated",
                 Equipment = equipment,
             };
             _context.Histories.Add(historyEntry);

--- a/Test/TestsController/ApiEquipmentControllerTests.cs
+++ b/Test/TestsController/ApiEquipmentControllerTests.cs
@@ -62,7 +62,7 @@ namespace Test.TestsController
         [Fact]
         public void TestControllerContainsExpectedNumberOfPublicMethods()
         {
-            ControllerReflection.ControllerPublicMethods(17);
+            ControllerReflection.ControllerPublicMethods(18);
         }
 
         [Fact]
@@ -187,6 +187,17 @@ namespace Test.TestsController
             responseType = ControllerReflection.MethodExpectedAttribute<ProducesResponseTypeAttribute>("SearchAttributes", 3 + countAdjustment, "SearchAttributes", showListOfAttributes: false);
             responseType.ElementAt(0).Type.GenericTypeArguments.ElementAt(0).Name.ShouldBe("Equipment");
             responseType.ElementAt(0).StatusCode.ShouldBe(StatusCodes.Status200OK);
+
+            //17
+            ControllerReflection.MethodExpectedAttribute<HttpPostAttribute>("Duplicate", 4 + countAdjustment, "Duplicate", showListOfAttributes: false);
+            ControllerReflection.MethodExpectedAttribute<AsyncStateMachineAttribute>("Duplicate", 4 + countAdjustment, "Duplicate", showListOfAttributes: false);
+            responseType = ControllerReflection.MethodExpectedAttribute<ProducesResponseTypeAttribute>("Duplicate", 4 + countAdjustment, "Duplicate", showListOfAttributes: false);
+            responseType.ElementAt(0).Type.Name.ShouldBe("Equipment");
+            responseType.ElementAt(0).StatusCode.ShouldBe(StatusCodes.Status200OK);
+            response2 = ControllerReflection.MethodExpectedAttribute<ConsumesAttribute>("Duplicate", 4 + countAdjustment, "Duplicate", showListOfAttributes: false);
+            response2.Count().ShouldBe(1);
+            response2.ElementAt(0).ContentTypes.Count.ShouldBe(1);
+            response2.ElementAt(0).ContentTypes.ElementAt(0).ShouldBe(MediaTypeNames.Application.Json);
 
         }
 


### PR DESCRIPTION
closes #1144 

adds option to duplicate equipment, which copies all properties except serial number, management id, and assignment details. on creation, adds note in history that it was copied off an existing asset–however, it doesn't specify which one, not sure if it should.