### PR TITLE
Rh/supervisor view

### DIFF
--- a/Keas.Mvc/Controllers/ReportController.cs
+++ b/Keas.Mvc/Controllers/ReportController.cs
@@ -14,7 +14,6 @@ using Keas.Core.Domain;
 
 namespace Keas.Mvc.Controllers
 {
-    [Authorize(Policy = AccessCodes.Codes.AnyRole)]
     public class ReportController : SuperController
     {
         private readonly ApplicationDbContext _context;
@@ -35,6 +34,7 @@ namespace Keas.Mvc.Controllers
             return View(model);
         }
 
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<ActionResult> PersonActions(DateTime? startDate, DateTime? endDate)
         {
             var team = await _context.Teams.SingleAsync(a => a.Slug == Team);
@@ -64,13 +64,14 @@ namespace Keas.Mvc.Controllers
             return View(model);
         }
 
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<ActionResult> ExpiringItems(DateTime? expiresBefore = null, string showType = "All")
         {
             var model = await _reportService.ExpiringItems(null, Team, expiresBefore, showType);
             return View(model);
         }
 
-
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<ActionResult> SupervisorDirectReports(int personID = 0)
         {
             var model = await SupervisorReportViewModel.Create(_context, Team, personID);
@@ -132,6 +133,7 @@ namespace Keas.Mvc.Controllers
         }
         
        
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<IActionResult> UnAcceptedItems(string showType = "All")
         {
             var userRoles = await _securityService.GetUserRoleNamesInTeamOrAdmin(Team);
@@ -140,6 +142,7 @@ namespace Keas.Mvc.Controllers
 
         }
 
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<IActionResult> KeyValues()
         {
             var model = await KeyValueReportViewModel.Create(_context, Team);
@@ -187,11 +190,13 @@ namespace Keas.Mvc.Controllers
             return View(await _reportService.EquipmentHistory(null, Team, id)) ;
         }
 
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<IActionResult> PersonEquipmentHistoryReport(int id)
         {
             return View(await _reportService.PersonEquipmentHistory(null, Team, id));
         }
 
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<IActionResult> AccessReport()
         {
             var accessList = await _reportService.AccessList(null, Team);
@@ -238,6 +243,7 @@ namespace Keas.Mvc.Controllers
             return View(model);
         }
 
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<IActionResult> PeopleInTeam(bool hideInactive = true)
         {
             var team = await _context.Teams.SingleAsync(a => a.Slug == Team);
@@ -256,6 +262,7 @@ namespace Keas.Mvc.Controllers
             return View(model);
         }
 
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<IActionResult> PeopleLeavingWithAssets()
         {
             var theDate = DateTime.UtcNow.AddDays(30).Date;
@@ -265,6 +272,7 @@ namespace Keas.Mvc.Controllers
             return View(peopleQuery);
         }
 
+        [Authorize(Policy = AccessCodes.Codes.AnyRole)]
         public async Task<IActionResult> InActiveSpaces()
         {
             var spaceQuery = await _reportService.InactiveSpaces(Team);

--- a/Keas.Mvc/Controllers/SupervisorController.cs
+++ b/Keas.Mvc/Controllers/SupervisorController.cs
@@ -1,0 +1,61 @@
+using System;
+using Keas.Core.Data;
+using Keas.Mvc.Models;
+using Keas.Mvc.Services;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Keas.Core.Helper;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Keas.Mvc.Controllers
+{
+    [Authorize]
+    public class SupervisorController : SuperController
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ISecurityService _securityService;
+        private readonly ITeamsManager _teamsManager;
+
+
+        public SupervisorController(ApplicationDbContext context, ISecurityService _securityService, IEventService _eventService, ITeamsManager teamsManager)
+        {
+            _context = context;
+            this._securityService = _securityService;
+            _teamsManager = teamsManager;
+        }
+
+        public IActionResult RefreshPermissions()
+        {
+            _teamsManager.ClearTeams();
+            return RedirectToAction("SelectTeam");
+        }
+
+        public async Task<IActionResult> MyStaff()
+        {   
+            var person = await _securityService.GetPerson(Team);
+            if(person == null){
+                 Message = "You are not yet added to the system.";
+                return RedirectToAction("NoAccess","Home");
+            }
+            var viewmodel = await MyStaffListModel.Create(_context, person);
+
+            return View(viewmodel);
+        }
+
+        public async Task<IActionResult> StaffStuff(int underlingId)
+        {   
+            var supervisor = await _securityService.GetPerson(Team);
+            if(supervisor == null){
+                 Message = "You are not yet added to the system.";
+                return RedirectToAction("NoAccess","Home");
+            }
+            var underling = await _context.People.Include(p=> p.Team).FirstOrDefaultAsync(p=> p.Id==underlingId && p.SupervisorId == supervisor.Id);
+            var viewmodel = await MyStaffListItem.Create(_context, underling);
+
+            return View(viewmodel);
+        }
+
+    }
+}

--- a/Keas.Mvc/Controllers/SupervisorController.cs
+++ b/Keas.Mvc/Controllers/SupervisorController.cs
@@ -44,14 +44,17 @@ namespace Keas.Mvc.Controllers
             return View(viewmodel);
         }
 
-        public async Task<IActionResult> StaffStuff(int underlingId)
+        public async Task<IActionResult> StaffStuff(int id) // id of staff being viewed
         {   
             var supervisor = await _securityService.GetPerson(Team);
             if(supervisor == null){
                  Message = "You are not yet added to the system.";
                 return RedirectToAction("NoAccess","Home");
             }
-            var underling = await _context.People.Include(p=> p.Team).FirstOrDefaultAsync(p=> p.Id==underlingId && p.SupervisorId == supervisor.Id);
+            var underling = await _context.People.Include(p=> p.Team).FirstOrDefaultAsync(p=> p.Id==id && p.SupervisorId == supervisor.Id);
+            if(underling == null){
+                return RedirectToAction("AccessDenied","Account"); // is this the best way to do this? -river
+            }
             var viewmodel = await MyStaffListItem.Create(_context, underling);
 
             return View(viewmodel);

--- a/Keas.Mvc/Models/MyStaffListModel.cs
+++ b/Keas.Mvc/Models/MyStaffListModel.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using Keas.Core.Data;
+using Keas.Core.Domain;
+using System.Linq;
+using System.Threading.Tasks;
+using Keas.Mvc.Services;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq.Expressions;
+
+namespace Keas.Mvc.Models
+{
+    public class MyStaffListModel
+    {
+        public List<Person> People { get; set; }
+
+        public static async Task<MyStaffListModel> Create(ApplicationDbContext context, Person person)
+        {   
+            var viewModel = new MyStaffListModel
+            {
+                People = await context.People.Where(p => p.TeamId == person.TeamId && p.Active && p.SupervisorId == person.Id)
+                    .Include(p => p.Team)
+                    .OrderBy(p => p.LastName).ThenBy(p => p.FirstName)
+                    .AsNoTracking().ToListAsync()
+            };
+            return viewModel;
+        }
+
+    }
+
+    public class MyStaffListItem
+    {
+        public List<KeySerial> KeySerials { get; set; }
+        public List<Equipment> Equipment { get; set; }
+        public List<Access> Access { get; set; }
+        public List<Workstation> Workstations { get; set; }
+        public List<Document> Documents { get; set; }
+        public Func<string, string> DocumentUrlResolver { get; set; }
+        public List<History> Histories { get; set; }
+        public bool PendingItems { get; set; }
+        public IEnumerable<Team> TeamsWithPendingAssignments { get; set; }
+
+
+        public static async Task<MyStaffListItem> Create(ApplicationDbContext context, Person person)
+        {   
+            var viewModel = new MyStaffListItem
+            {
+                KeySerials = await context.KeySerials.Include(s=> s.Key).ThenInclude(k=> k.KeyXSpaces).ThenInclude(kxp=> kxp.Space).Include(s=> s.KeySerialAssignment)
+                    .Where(s=> s.KeySerialAssignment.Person==person).AsNoTracking().ToListAsync(),
+                Equipment = await context.Equipment.Include(e => e.Space).Include(e=> e.Assignment).Where(e => e.Assignment.Person == person).AsNoTracking().ToListAsync(),
+                Access = await context.Access
+                    .Where(x => x.Active && x.Assignments.Any(y => y.Person == person))
+                    .Select(a => new Access()
+                    {
+                        Id = a.Id,
+                        Name = a.Name,
+                        Assignments = a.Assignments.Where(b => b.Person == person).Select(
+                            c => new AccessAssignment()
+                            {
+                                AccessId = c.AccessId,
+                                ExpiresAt = c.ExpiresAt,
+                                Id = c.Id
+                            }
+                        ).ToList()
+                    })
+                    .AsNoTracking().ToListAsync(),
+                Workstations = await context.Workstations.Include(w=> w.Assignment).Include(w=> w.Space).Where(w=> w.Assignment.Person==person).AsNoTracking().ToListAsync(),
+                Documents = await context.Documents.Where(d => d.Person == person).AsNoTracking().ToListAsync(),
+                Histories = await context.Histories.Where(x => x.Target == person)
+                    .OrderByDescending(x => x.ActedDate)
+                    .Take(10).AsNoTracking().ToListAsync()
+            };
+
+            return viewModel;
+        }
+
+    }
+}

--- a/Keas.Mvc/Models/MyStaffListModel.cs
+++ b/Keas.Mvc/Models/MyStaffListModel.cs
@@ -30,6 +30,7 @@ namespace Keas.Mvc.Models
 
     public class MyStaffListItem
     {
+        public Person Person { get; set;}
         public List<KeySerial> KeySerials { get; set; }
         public List<Equipment> Equipment { get; set; }
         public List<Access> Access { get; set; }
@@ -45,6 +46,7 @@ namespace Keas.Mvc.Models
         {   
             var viewModel = new MyStaffListItem
             {
+                Person = person,
                 KeySerials = await context.KeySerials.Include(s=> s.Key).ThenInclude(k=> k.KeyXSpaces).ThenInclude(kxp=> kxp.Space).Include(s=> s.KeySerialAssignment)
                     .Where(s=> s.KeySerialAssignment.Person==person).AsNoTracking().ToListAsync(),
                 Equipment = await context.Equipment.Include(e => e.Space).Include(e=> e.Assignment).Where(e => e.Assignment.Person == person).AsNoTracking().ToListAsync(),

--- a/Keas.Mvc/Views/Confirm/MyStuff.cshtml
+++ b/Keas.Mvc/Views/Confirm/MyStuff.cshtml
@@ -38,6 +38,16 @@
     </div>
   </div>
   <div class="card-content">
+        <div class="card people-color">
+      <div class="card-header-people">
+        <div class="card-head">
+  <h2><i class="fas fa-key fa-xs"></i> People</h2>
+        </div>
+      </div>
+      <div class="card-content">
+          <a asp-action="MyStaff" asp-controller="Supervisor">View All People You Supervise</a>
+      </div>
+    </div>
     <div class="card keys-color">
       <div class="card-header-keys">
         <div class="card-head">

--- a/Keas.Mvc/Views/Confirm/MyStuff.cshtml
+++ b/Keas.Mvc/Views/Confirm/MyStuff.cshtml
@@ -207,7 +207,7 @@
               <td><a href="@Model.DocumentUrlResolver(document.EnvelopeId)" target="_blank">View</a></td>
             </tr>
             }
-            @if(!Model.Workstations.Any()){
+            @if(!Model.Documents.Any()){
               <tr>
                 <td colspan="4">You have no documents assigned.</td>
               </tr>

--- a/Keas.Mvc/Views/Report/Index.cshtml
+++ b/Keas.Mvc/Views/Report/Index.cshtml
@@ -31,6 +31,9 @@
                 </ul>
             </div>
         }
+        @if (Model.Contains(Role.Codes.KeyMaster) || Model.Contains(Role.Codes.EquipmentMaster) || Model.Contains(Role.Codes.AccessMaster) // basically Codes.AnyRole
+             || Model.Contains(Role.Codes.SpaceMaster) || Model.Contains(Role.Codes.DocumentMaster) || Model.Contains(Role.Codes.Admin) || Model.Contains(Role.Codes.PersonManager))
+        {
         <div class="report-list people-color col-md-3">
             <h3><i class="fas fa-users fa-xs"></i> People Reports</h3>
                 <ul>
@@ -54,6 +57,7 @@
                     }
                 </ul>
         </div>
+        }
         @if (Model.Contains(Role.Codes.SpaceMaster) || Model.Contains(Role.Codes.DepartmentalAdmin))
         {
             <div class="report-list spaces-color col-md-3">
@@ -108,22 +112,37 @@
                     </ul>
                 </div>
         }
-        <div class="report-list general-color col-md-3">
-            <h3><i class="fas fa-list fa-xs"></i> General Reports</h3>
-            <ul>
-                <li>
-                    <a asp-action="ExpiringItems">Expiring <span style="white-space: nowrap;">Items <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></span></a>
-                </li>
-                @if (Model.Contains(Role.Codes.EquipmentMaster) || Model.Contains(Role.Codes.DepartmentalAdmin) || Model.Contains(Role.Codes.KeyMaster) || Model.Contains(Role.Codes.SpaceMaster))
-                {
+        @if (Model.Contains(Role.Codes.KeyMaster) || Model.Contains(Role.Codes.EquipmentMaster) || Model.Contains(Role.Codes.AccessMaster) // basically Codes.AnyRole
+             || Model.Contains(Role.Codes.SpaceMaster) || Model.Contains(Role.Codes.DocumentMaster) || Model.Contains(Role.Codes.Admin) || Model.Contains(Role.Codes.PersonManager))
+            {
+                <div class="report-list general-color col-md-3">
+                    <h3><i class="fas fa-list fa-xs"></i> General Reports</h3>
+                    <ul>
+                        <li>
+                            <a asp-action="ExpiringItems">Expiring <span style="white-space: nowrap;">Items <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></span></a>
+                        </li>
+                        @if (Model.Contains(Role.Codes.EquipmentMaster) || Model.Contains(Role.Codes.DepartmentalAdmin) || Model.Contains(Role.Codes.KeyMaster) || Model.Contains(Role.Codes.SpaceMaster))
+                        {
+                            <li>
+                                <a asp-action="UnAcceptedItems">Items Pending <span style="white-space: nowrap;">Acceptance <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></span></a>
+                            </li>
+                        }
+                        <li>
+                            <a asp-action="InActiveSpaces">InActive Spaces With <span style="white-space: nowrap;">Assets <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></span></a>
+                        </li>
+                    </ul>
+                </div>
+            }
+            <div class="report-list general-color col-md-3">
+                <h3><i class="fas fa-hdd fa-xs"></i> Personal Reports</h3>
+                <ul>
                     <li>
-                        <a asp-action="UnAcceptedItems">Items Pending <span style="white-space: nowrap;">Acceptance <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></span></a>
-                    </li>
-                }
-                <li>
-                    <a asp-action="InActiveSpaces">InActive Spaces With <span style="white-space: nowrap;">Assets <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></span></a>
-                </li>
-            </ul>
+                        <a asp-action="MyStaff" asp-controller="Supervisor">View All People You<span style="white-space: nowrap;"> Supervise <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></span></a>
+                    </li>   
+                    <li>
+                        <a asp-action="SupervisedEquipmentReport">TODO: View All Equipment of People You<span style="white-space: nowrap;"> Supervise <i class="fas fa-chevron-right fa-sm" aria-hidden="true"></i></span></a>
+                    </li>    
+                </ul>
             </div>
         </div>
       </div>

--- a/Keas.Mvc/Views/Shared/_Layout.cshtml
+++ b/Keas.Mvc/Views/Shared/_Layout.cshtml
@@ -139,6 +139,9 @@
                             <li class='@(activeMenu == "MyStuff" ? "nav-item nav-active" : "nav-item")'>
                                 <a class="nav-link" asp-controller="Confirm" asp-action="MyStuff">My Stuff</a>
                             </li>
+                            <li class='@(activeMenu == "Report" ? "nav-item nav-active" : "nav-item")'>
+                                <a class="nav-link" asp-controller="Report" asp-action="Index">Reports</a>
+                            </li>
                         }
 
                         if ((await AuthorizationService.AuthorizeAsync(User, AccessCodes.Codes.DepartmentAdminAccess)).Succeeded || (await AuthorizationService.AuthorizeAsync(User, AccessCodes.Codes.PersonManagerAccess)).Succeeded)

--- a/Keas.Mvc/Views/Supervisor/MyStaff.cshtml
+++ b/Keas.Mvc/Views/Supervisor/MyStaff.cshtml
@@ -1,0 +1,52 @@
+@using Keas.Core.Extensions
+@model Keas.Mvc.Models.MyStaffListModel
+
+@{
+    ViewData["Title"] = "MyStaff";
+}
+
+<div class="card">
+  <div class="card-header-primary">
+    <div class="row justify-content-between">
+      <div class="card-head">
+        <h2>MyStaff</h2>
+      </div>
+    </div>
+  </div>
+  <div class="card-content">
+    <div class="card people-color">
+      <div class="card-header-people">
+        <div class="card-head">
+          <h2><i class="fas fa-hdd fa-xs"></i> People</h2></div>
+      </div>
+      <div class="card-content">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Stuff</th>
+            </tr>
+          </thead>
+          <tbody>
+            @foreach (var person in Model.People) {
+            <tr>
+              <td>@Html.DisplayFor(modelItem => person.NameV2)</td>
+              <td>@Html.DisplayFor(modelItem => person.Email)</td>
+              <td>
+                @Html.ActionLink("View", "StaffStuff", "Supervisor", new { underlingId= @person.Id })
+              </td>
+            </tr>
+            }
+            @if(!Model.People.Any()){
+              <tr>
+                <td colspan="4">You do not supervise anyone.</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/Keas.Mvc/Views/Supervisor/MyStaff.cshtml
+++ b/Keas.Mvc/Views/Supervisor/MyStaff.cshtml
@@ -34,7 +34,7 @@
               <td>@Html.DisplayFor(modelItem => person.NameV2)</td>
               <td>@Html.DisplayFor(modelItem => person.Email)</td>
               <td>
-                @Html.ActionLink("View", "StaffStuff", "Supervisor", new { underlingId= @person.Id })
+                @Html.ActionLink("View", "StaffStuff", "Supervisor", new { id= @person.Id })
               </td>
             </tr>
             }

--- a/Keas.Mvc/Views/Supervisor/StaffStuff.cshtml
+++ b/Keas.Mvc/Views/Supervisor/StaffStuff.cshtml
@@ -1,0 +1,250 @@
+@using Keas.Core.Extensions
+@model Keas.Mvc.Models.MyStaffListItem
+
+@{
+    ViewData["Title"] = "Staff Stuff";
+}
+@if(Model.PendingItems){
+    var currentSlug = TempData["TeamName"] as string;
+    if (Model.TeamsWithPendingAssignments.Any(a => a.Slug != null && a.Slug == currentSlug))
+    {
+        <div class="alert alert-warning">
+            <div class="row justify-content-between align-middle">
+                <p>You have pending items!</p>
+                <a asp-controller="Confirm" asp-action="Confirm">Go to Accept page <i class="fas fa-arrow-right fa-xs"></i></a>
+            </div>
+        </div>
+    }
+    if (Model.TeamsWithPendingAssignments.Any(a => a.Slug != currentSlug))
+    {
+        <h3>You have items pending in other teams:</h3>
+        foreach (var teamWithPending in Model.TeamsWithPendingAssignments.Where(a => a.Slug != currentSlug))
+        {
+            <div class="alert alert-warning">
+                <div class="row justify-content-between align-middle">
+                    <p>You have pending items in team @teamWithPending.Name!</p>
+                    <a href='@string.Format("/{0}/Confirm/Confirm", teamWithPending.Slug)'>Go to Accept page <i class="fas fa-arrow-right fa-xs"></i></a>
+                </div>
+            </div>
+        }
+    }
+}
+<div class="card">
+  <div class="card-header-primary">
+    <div class="row justify-content-between">
+      <div class="card-head">
+        <h2>MyStuff</h2>
+      </div>
+    </div>
+  </div>
+  <div class="card-content">
+    <div class="card keys-color">
+      <div class="card-header-keys">
+        <div class="card-head">
+  <h2><i class="fas fa-key fa-xs"></i> Keys</h2>
+        </div>
+      </div>
+      <div class="card-content">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Code</th>
+              <th>Serial</th>
+              <th>Name</th>
+              <th>Expiration</th>
+              <th>Accepted?</th>              
+            </tr>
+          </thead>
+          <tbody>
+            @foreach (var serial in Model.KeySerials) {
+            <tr>
+              <td>@serial.Key.Code</td>
+              <td>@serial.Number</td>
+              <td>@serial.Key.Name</td>
+              <td>@serial.KeySerialAssignment.ExpiresAt.ToShortDateString()</td>
+              <td>@serial.KeySerialAssignment.ConfirmedAt.AcceptedWithDate()</td>            
+            </tr>
+            }
+
+            @if (!Model.KeySerials.Any()) {
+              <tr>
+                <td colspan="4">You have no Keys assigned.</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="card equipment-color">
+      <div class="card-header-equipment">
+        <div class="card-head">
+          <h2><i class="fas fa-hdd fa-xs"></i> Equipment</h2></div>
+      </div>
+      <div class="card-content">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Serial Number</th>
+              <th>Name</th>
+              <th>Make</th>
+              <th>Model</th>
+              <th>Room</th>
+              <th>Expiration</th>
+              <th>Accepted?</th>
+            </tr>
+          </thead>
+          <tbody>
+            @foreach (var equipment in Model.Equipment) {
+            <tr>
+              <td>@equipment.SerialNumber</td>
+              <td>@equipment.Name</td>
+              <td>@equipment.Make</td>
+              <td>@equipment.Model</td>
+              <td>@equipment.Space?.ShortName</td>
+              <td>@equipment.Assignment.ExpiresAt.ToShortDateString()</td>
+              <td>@equipment.Assignment.ConfirmedAt.AcceptedWithDate()</td>
+            </tr>
+            }
+            @if(!Model.Equipment.Any()){
+              <tr>
+                <td colspan="4">You have no equipment assigned.</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card access-color">
+      <div class="card-header-access">
+        <div class="card-head">
+          <h2><i class="fas fa-address-card fa-xs"></i> Access</h2></div>
+      </div>
+      <div class="card-content">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Expiration</th>
+            </tr>
+          </thead>
+          <tbody>
+            @foreach (var access in Model.Access) {
+            <tr>
+              <td>@access.Name</td>
+              <td>@access.Assignments.First().ExpiresAt.ToShortDateString()</td>
+            </tr>
+            }
+             @if(!Model.Access.Any()){
+              <tr>
+                <td colspan="2">You have no access assigned.</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+
+    <div class="card spaces-color">
+      <div class="card-header-spaces">
+        <div class="card-head">
+          <h2><i class="fas fa-building fa-xs"></i> Workstations</h2></div>
+      </div>
+      <div class="card-content">
+
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Room</th>
+              <th>Expiration</th>
+              <th>Accepted?</th>
+            </tr>
+          </thead>
+          <tbody>
+            @foreach (var workstation in Model.Workstations) {
+            <tr>
+              <td>@workstation.Title</td>
+              <td>@workstation.Space.ShortName</td>
+              <td>@workstation.Assignment.ExpiresAt.ToShortDateString()</td>
+              <td>@workstation.Assignment.ConfirmedAt.AcceptedWithDate()</td>
+            </tr>
+            }
+            @if(!Model.Workstations.Any()){
+              <tr>
+                <td colspan="4">You have no workstations assigned.</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+
+      </div>
+    </div>
+
+    <div class="card documents-color">
+      <div class="card-header-documents">
+        <div class="card-head">
+          <h2><i class="fas fa-briefcase fa-xs"></i> Documents</h2></div>
+      </div>
+      <div class="card-content">
+
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Status</th>
+              <th>Date</th>
+              <th>Link</th>
+            </tr>
+          </thead>
+          <tbody>
+            @foreach (var document in Model.Documents) {
+            <tr>
+              <td>@document.Name</td>
+              <td>@document.Status</td>
+              <td>@(document.CompletedAt.HasValue ? document.CompletedAt : document.CreatedAt)</td>
+              <td><a href="@Model.DocumentUrlResolver(document.EnvelopeId)" target="_blank">View</a></td>
+            </tr>
+            }
+            @if(!Model.Workstations.Any()){
+              <tr>
+                <td colspan="4">You have no documents assigned.</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+
+      </div>
+    </div>
+
+    <div class="card history-color">
+      <div class="card-head">
+        <h2><i class="fas fa-history fa-xs"></i> History</h2></div>
+      <div class="card-content">
+
+
+        <table class="table">
+          <thead>
+            <tr>
+            </tr>
+          </thead>
+          <tbody>
+            @foreach (var history in Model.Histories) {
+            <tr>
+              <td>@history.ActedDate.ToShortDateString()</td>
+              <td>@history.Description</td>
+            </tr>
+            }
+            @if(!Model.Histories.Any()){
+              <tr>
+                <td colspan="2">No history to display</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/Keas.Mvc/Views/Supervisor/StaffStuff.cshtml
+++ b/Keas.Mvc/Views/Supervisor/StaffStuff.cshtml
@@ -33,7 +33,7 @@
   <div class="card-header-primary">
     <div class="row justify-content-between">
       <div class="card-head">
-        <h2>MyStuff</h2>
+        <h2>@Model.Person.Name's Stuff</h2>
       </div>
     </div>
   </div>
@@ -68,7 +68,7 @@
 
             @if (!Model.KeySerials.Any()) {
               <tr>
-                <td colspan="4">You have no Keys assigned.</td>
+                <td colspan="4">@Model.Person.Name has no Keys assigned.</td>
               </tr>
             }
           </tbody>
@@ -107,7 +107,7 @@
             }
             @if(!Model.Equipment.Any()){
               <tr>
-                <td colspan="4">You have no equipment assigned.</td>
+                <td colspan="4">@Model.Person.Name has no equipment assigned.</td>
               </tr>
             }
           </tbody>
@@ -137,7 +137,7 @@
             }
              @if(!Model.Access.Any()){
               <tr>
-                <td colspan="2">You have no access assigned.</td>
+                <td colspan="2">@Model.Person.Name has no access assigned.</td>
               </tr>
             }
           </tbody>
@@ -173,7 +173,7 @@
             }
             @if(!Model.Workstations.Any()){
               <tr>
-                <td colspan="4">You have no workstations assigned.</td>
+                <td colspan="4">@Model.Person.Name has no workstations assigned.</td>
               </tr>
             }
           </tbody>
@@ -207,9 +207,9 @@
               <td><a href="@Model.DocumentUrlResolver(document.EnvelopeId)" target="_blank">View</a></td>
             </tr>
             }
-            @if(!Model.Workstations.Any()){
+            @if(!Model.Documents.Any()){
               <tr>
-                <td colspan="4">You have no documents assigned.</td>
+                <td colspan="4">@Model.Person.Name has no documents assigned.</td>
               </tr>
             }
           </tbody>


### PR DESCRIPTION
closes #789 and closes #712 

not done yet, but i want opinions on how i'm doing this because i'm not convinced it's the best way. i made a "MyStaff" page accessible through my stuff -> people. or at /Supervisor/MyStaff (guess i could just make it index). on that page is a link to a /Supervisor/StaffStuff/{id} page, where a supervisor can see all the assets/details that would be on a "MyStuff" page

i started to add a report as well, following #712. opened reports index page but started to hate it

i don't really like adding People to MyStuff when most users will not need to see that. i could put it at the bottom (ruining the spelling of PEAKS... EAKSP? lol). could put in another tab but that has the same issue of showing for everyone when most people won't need it. i also don't really like having the Reports tab visible to everyone if it's not going to be useful, but doubt any individual user would care about a report for their assets. there's no role or anything special for being a supervisor, so hard to target in the nav 

we do already have a Report/SupervisorDirectReports page, that could be more useful (just lists users like my MyStaff page but links to the react person details) but is behind AnyRole auth 

so, thoughts? this is what reports look like now if you have no permissions. first one links to what i added ☝️ but should this all be report(s)? how should it interact with Report/SupervisorDirectReports? i could combine it so someone without a role can view those reports but only see their own information (i.e. only select themself as a supervisor and only see data for who they supervise)
![image](https://github.com/ucdavis/Peaks/assets/27025973/a9b4bfbc-3912-488f-9800-fbaa6136a8be)
