### PR TITLE
fix useEffect() infinite loop

### DIFF
--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentDetails.tsx
@@ -47,7 +47,9 @@ const EquipmentDetails = (props: IProps) => {
     };
 
     fetchDetails(props.selectedEquipment.id);
-  }, [props.selectedEquipment, context, props]);
+    // it wants us to add props.closeModal and props.updateSelectedEquipment to the dependency array, but that causes an infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.selectedEquipment.id, context]);
 
   if (!props.selectedEquipment) {
     return null;

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentDetails.tsx
@@ -19,9 +19,11 @@ interface IProps {
 
 const EquipmentDetails = (props: IProps) => {
   const context = useContext(Context);
+  const { selectedEquipment } = props;
+  const equipmentId = selectedEquipment?.id;
 
   useEffect(() => {
-    if (!props.selectedEquipment) {
+    if (!equipmentId) {
       return;
     }
     const fetchDetails = async (id: number) => {
@@ -46,16 +48,16 @@ const EquipmentDetails = (props: IProps) => {
       props.updateSelectedEquipment(equipment);
     };
 
-    fetchDetails(props.selectedEquipment.id);
+    fetchDetails(equipmentId);
     // it wants us to add props.closeModal and props.updateSelectedEquipment to the dependency array, but that causes an infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.selectedEquipment, context]);
+  }, [equipmentId, context]);
 
-  if (!props.selectedEquipment) {
+  if (!selectedEquipment) {
     return null;
   }
 
-  const equipment = props.selectedEquipment;
+  const equipment = selectedEquipment;
 
   return (
     <div>

--- a/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Equipment/EquipmentDetails.tsx
@@ -49,7 +49,7 @@ const EquipmentDetails = (props: IProps) => {
     fetchDetails(props.selectedEquipment.id);
     // it wants us to add props.closeModal and props.updateSelectedEquipment to the dependency array, but that causes an infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.selectedEquipment.id, context]);
+  }, [props.selectedEquipment, context]);
 
   if (!props.selectedEquipment) {
     return null;

--- a/Keas.Mvc/ClientApp/src/components/Keys/KeySerialContainer.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/KeySerialContainer.tsx
@@ -44,12 +44,12 @@ const KeySerialContainer = (props: IProps) => {
   const context = useContext(Context);
   const history = useHistory();
   const params: IMatchParams = useParams();
+  const { selectedPerson, selectedKey } = props;
 
   useEffect(() => {
     if (!PermissionsUtil.canViewKeys(context.permissions)) {
       return;
     }
-    const { selectedPerson, selectedKey } = props;
 
     // are we getting the person's key or the team's?
     let keyFetchUrl = '';
@@ -80,7 +80,7 @@ const KeySerialContainer = (props: IProps) => {
     };
 
     fetchKeySerials();
-  }, [context, props]);
+  }, [context, selectedPerson, selectedKey]);
 
   const renderAssignModal = (selectedId: number, keySerial: IKeySerial) => {
     return (

--- a/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
@@ -22,14 +22,15 @@ interface IProps {
 const KeySerialDetails = (props: IProps) => {
   const context = useContext(Context);
   const { selectedKeySerial } = props;
+  const keySerialId = selectedKeySerial?.id;
 
   useEffect(() => {
-    if (!props.selectedKeySerial) {
+    if (!keySerialId) {
       return;
     }
-    fetchDetails(props.selectedKeySerial.id);
+    fetchDetails(selectedKeySerial.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.selectedKeySerial, context]);
+  }, [keySerialId, context]);
 
   if (!selectedKeySerial) {
     return null;

--- a/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
@@ -29,7 +29,7 @@ const KeySerialDetails = (props: IProps) => {
     }
     fetchDetails(props.selectedKeySerial.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.selectedKeySerial.id, context]);
+  }, [props.selectedKeySerial, context]);
 
   if (!selectedKeySerial) {
     return null;

--- a/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Keys/KeySerialDetails.tsx
@@ -28,7 +28,8 @@ const KeySerialDetails = (props: IProps) => {
       return;
     }
     fetchDetails(props.selectedKeySerial.id);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.selectedKeySerial.id, context]);
 
   if (!selectedKeySerial) {
     return null;

--- a/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
@@ -50,7 +50,7 @@ const WorkstationDetails = (props: IProps) => {
     fetchDetails(props.selectedWorkstation.id);
     // it wants us to add props.closeModal and props.updateSelectedWorkstation to the dependency array, but that causes an infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.selectedWorkstation.id, context]);
+  }, [props.selectedWorkstation, context]);
 
   if (!props.selectedWorkstation) {
     return null;

--- a/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
@@ -19,10 +19,11 @@ interface IProps {
 
 const WorkstationDetails = (props: IProps) => {
   const context = useContext(Context);
-  const workstation = props.selectedWorkstation;
+  const { selectedWorkstation: workstation } = props;
+  const workstationId = workstation?.id;
 
   useEffect(() => {
-    if (!props.selectedWorkstation) {
+    if (!workstationId) {
       return;
     }
     const fetchDetails = async (id: number) => {
@@ -47,10 +48,10 @@ const WorkstationDetails = (props: IProps) => {
       props.updateSelectedWorkstation(workstation);
     };
 
-    fetchDetails(props.selectedWorkstation.id);
+    fetchDetails(workstationId);
     // it wants us to add props.closeModal and props.updateSelectedWorkstation to the dependency array, but that causes an infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.selectedWorkstation, context]);
+  }, [workstationId, context]);
 
   if (!props.selectedWorkstation) {
     return null;

--- a/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
+++ b/Keas.Mvc/ClientApp/src/components/Workstations/WorkstationDetails.tsx
@@ -48,7 +48,9 @@ const WorkstationDetails = (props: IProps) => {
     };
 
     fetchDetails(props.selectedWorkstation.id);
-  }, [context, props]);
+    // it wants us to add props.closeModal and props.updateSelectedWorkstation to the dependency array, but that causes an infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.selectedWorkstation.id, context]);
 
   if (!props.selectedWorkstation) {
     return null;


### PR DESCRIPTION
eslint wants the functions we're using in our useEffect() to be part of the dependency array, but our functions are `() => {}` so it changes every time and loops. stupid to use the entire props in the dep array regardless, that's my bad. i believe this is a case where we'd want to use `useCallback()` but i'll get that working in a different PR