### PR TITLE
Updates FIS Org to use OrgCode only

### DIFF
--- a/Keas.Core/Domain/FinancialOrganization.cs
+++ b/Keas.Core/Domain/FinancialOrganization.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text;
@@ -13,9 +13,9 @@ namespace Keas.Core.Domain
 
         [StringLength(1)]
         [Required]
-        public string Chart { get; set; }
+        public string Chart { get; set; } = "X";
 
-        [StringLength(4)]
+        [StringLength(6)]
         [Required]
         public string OrgCode { get; set; }
         
@@ -23,7 +23,7 @@ namespace Keas.Core.Domain
         public Team Team { get; set; }
         public int TeamId { get; set; }
 
-        public string ChartAndOrg => string.Format("{0}-{1}", Chart, OrgCode);
+        public string ChartAndOrg => string.Format("{0}", OrgCode);
 
     }
 }

--- a/Keas.Mvc/Controllers/TeamAdminController.cs
+++ b/Keas.Mvc/Controllers/TeamAdminController.cs
@@ -110,7 +110,8 @@ namespace Keas.Mvc.Controllers
             {
                 return NotFound();
             }
-            var foundInSpaces = await _context.Spaces.FirstOrDefaultAsync(a => a.Active && a.ChartNum == model.Chart && a.OrgId == model.OrgCode);
+            //var foundInSpaces = await _context.Spaces.FirstOrDefaultAsync(a => a.Active && a.ChartNum == model.Chart && a.OrgId == model.OrgCode);
+            var foundInSpaces = await _context.Spaces.FirstOrDefaultAsync(a => a.Active && a.OrgId == model.OrgCode);
             if (!await _financialService.ValidateFISOrg(model.Chart, model.OrgCode))
             {
                 if (foundInSpaces != null)
@@ -131,7 +132,7 @@ namespace Keas.Mvc.Controllers
                 }
             }
 
-            var FISOrg = new FinancialOrganization { Chart = model.Chart, OrgCode = model.OrgCode, Team = team };
+            var FISOrg = new FinancialOrganization { Chart = "X", OrgCode = model.OrgCode, Team = team };
 
             if (ModelState.IsValid)
             {

--- a/Keas.Mvc/Models/FISOrgAddModel.cs
+++ b/Keas.Mvc/Models/FISOrgAddModel.cs
@@ -9,10 +9,9 @@ namespace Keas.Mvc.Models
     public class FISOrgAddModel
     {
         [StringLength(1)]
-        [Required]
         public string Chart { get; set; }
 
-        [StringLength(4)]
+        [StringLength(6)]
         [Required]
         [Display(Name = "Org Code")]
         public string OrgCode { get; set; }

--- a/Keas.Mvc/Views/TeamAdmin/AddFISOrg.cshtml
+++ b/Keas.Mvc/Views/TeamAdmin/AddFISOrg.cshtml
@@ -13,11 +13,11 @@
             <div class="card-content col-lg-4">
                 <form asp-action="AddFISOrg">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                    <div class="form-group">
+@*                     <div class="form-group">
                         <label asp-for="Chart" class="control-label"></label>
                         <input asp-for="Chart" class="form-control" />
                         <span asp-validation-for="Chart" class="text-danger"></span>
-                    </div>
+                    </div> *@
                     <div class="form-group">
                         <label asp-for="OrgCode" class="control-label"></label>
                         <input asp-for="OrgCode" class="form-control" />

--- a/Keas.Mvc/Views/TeamAdmin/RemoveFISOrg.cshtml
+++ b/Keas.Mvc/Views/TeamAdmin/RemoveFISOrg.cshtml
@@ -15,12 +15,12 @@
         <div>
 
           <dl class="dl-horizontal">
-            <dt>
+@*             <dt>
                   @Html.DisplayNameFor(model => model.Chart)
               </dt>
             <dd>
               @Html.DisplayFor(model => model.Chart)
-            </dd>
+            </dd> *@
             <dt>
                   @Html.DisplayNameFor(model => model.OrgCode)
               </dt>

--- a/Keas.Sql/dbo/Tables/FISOrgs.sql
+++ b/Keas.Sql/dbo/Tables/FISOrgs.sql
@@ -1,7 +1,7 @@
-﻿CREATE TABLE [dbo].[FISOrgs] (
+CREATE TABLE [dbo].[FISOrgs] (
     [Id]      INT          IDENTITY (1, 1) NOT NULL,
     [Chart]   NVARCHAR (1) NOT NULL,
-    [OrgCode] NVARCHAR (4) NOT NULL,
+    [OrgCode] NVARCHAR (6) NOT NULL,
     [TeamId]  INT          NOT NULL,
     CONSTRAINT [PK_FISOrgs] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [FK_FISOrgs_Teams_TeamId] FOREIGN KEY ([TeamId]) REFERENCES [dbo].[Teams] ([Id]) ON DELETE CASCADE

--- a/Test/TestsDatabase/FinancialOrganizationTests.cs
+++ b/Test/TestsDatabase/FinancialOrganizationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Keas.Core.Domain;
@@ -49,7 +49,7 @@ namespace Test.TestsDatabase
             expectedFields.Add(new NameAndType("OrgCode", "System.String", new List<string>
             {
                 "[System.ComponentModel.DataAnnotations.RequiredAttribute()]",
-                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)4)]"
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)6)]"
             }));
             expectedFields.Add(new NameAndType("Team", "Keas.Core.Domain.Team", new List<string>
             {


### PR DESCRIPTION
Updates the financial organization to only require the OrgCode instead of Chart and OrgCode.
Removes the Chart field from the model and database. Chart is defaulted to "X" in the backend.
Increases OrgCode length to 6.

Relates to JCS/FisOrgCode