### PR TITLE
Optimize user retrieval for pending notifications

### DIFF
--- a/Keas.Core/Services/IEmailService.cs
+++ b/Keas.Core/Services/IEmailService.cs
@@ -589,7 +589,14 @@ namespace Keas.Core.Services
                 return;
             }
 
-            var notifications = _dbContext.Notifications.Where(a => a.Pending && a.User == user).Include(a => a.Team).Include(a => a.User).OrderBy(a => a.TeamId).ThenBy(a => a.DateTimeCreated).ToArray().GroupBy(a => a.TeamId);
+            var notifications = _dbContext.Notifications
+                .Where(a => a.Pending && a.UserId == user.Id)
+                .Include(a => a.Team)
+                .Include(a => a.User)
+                .OrderBy(a => a.TeamId)
+                .ThenBy(a => a.DateTimeCreated)
+                .ToArray()
+                .GroupBy(a => a.TeamId);
             if (!notifications.Any())
             {
                 return;

--- a/Keas.Jobs.SendMail/Program.cs
+++ b/Keas.Jobs.SendMail/Program.cs
@@ -47,7 +47,17 @@ namespace Keas.Jobs.SendMail
             var emailService = provider.GetService<IEmailService>();
 
             var counter = 0;
-            var usersWithPendingNotifications = dbContext.Notifications.Where(a => a.Pending).Select(s => s.User).Distinct().ToArray();
+            var usersWithPendingNotifications = dbContext.Notifications
+                .Where(a => a.Pending && a.UserId != null)
+                .Select(a => a.UserId)
+                .Distinct()
+                .Join(
+                    dbContext.Users,
+                    userId => userId,
+                    user => user.Id,
+                    (userId, user) => user)
+                .AsNoTracking()
+                .ToArray();
             if (usersWithPendingNotifications.Any())
             {
                 foreach (var user in usersWithPendingNotifications)


### PR DESCRIPTION
AI's suggest fix for email job failure

Refactors notification queries to use `UserId` for direct comparisons and improve the efficiency of fetching distinct users via a `Join` with `AsNoTracking()`. This prevents potential N+1 query issues and enhances robustness in the notification processing job.